### PR TITLE
Add ANSI based logging back to asana tools

### DIFF
--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -13,6 +13,7 @@ module Asana.App
 
 import Prelude
 
+import Asana.Logger (runANSILoggerT)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Logger
 import Control.Monad.Trans.Reader (ReaderT, asks, runReaderT)
@@ -53,7 +54,7 @@ runApp app action = do
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
 
-  runStderrLoggingT
+  runANSILoggerT
     $ filterLogger (\_ level -> level >= appLogLevel app)
     $ runReaderT action app
 

--- a/library/Asana/Logger.hs
+++ b/library/Asana/Logger.hs
@@ -1,0 +1,49 @@
+module Asana.Logger
+  ( runANSILoggerT
+  ) where
+
+import Prelude
+
+import Control.Monad.Logger (LogLevel(..), LoggingT, defaultLogStr, runLoggingT)
+import qualified Data.ByteString as BS
+import System.Console.ANSI
+  ( Color(Blue, Magenta, Red, Yellow)
+  , ColorIntensity(Dull)
+  , ConsoleLayer(Foreground)
+  , SGR(Reset, SetColor)
+  , hSetSGR
+  , setSGR
+  )
+import System.IO (Handle, stderr, stdout)
+import System.Log.FastLogger (fromLogStr)
+
+runANSILoggerT :: LoggingT m a -> m a
+runANSILoggerT = (`runLoggingT` logger)
+ where
+  labelEnd = fromIntegral $ fromEnum ']'
+  logger loc src level str = do
+    let
+      h = levelHandle level
+      (levelStr : logStr) =
+        BS.split labelEnd . fromLogStr $ defaultLogStr loc src level str
+    hSetSGR h [style level]
+    BS.hPutStr h $ BS.snoc levelStr labelEnd
+    hSetSGR h [Reset]
+    BS.hPutStr h $ BS.intercalate (BS.singleton labelEnd) logStr
+    setSGR [Reset]
+
+style :: LogLevel -> SGR
+style = \case
+  LevelDebug -> SetColor Foreground Dull Magenta
+  LevelInfo -> SetColor Foreground Dull Blue
+  LevelWarn -> SetColor Foreground Dull Yellow
+  LevelError -> SetColor Foreground Dull Red
+  LevelOther _ -> Reset
+
+levelHandle :: LogLevel -> Handle
+levelHandle = \case
+  LevelDebug -> stderr
+  LevelInfo -> stdout
+  LevelWarn -> stderr
+  LevelError -> stderr
+  LevelOther _ -> stdout

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,9 @@ library:
   dependencies:
     - aeson
     - aeson-casing
+    - ansi-terminal
+    - bytestring
+    - fast-logger
     - http-conduit
     - iso8601-time
     - load-env


### PR DESCRIPTION
Logs are hard to understand when they aren't colored. This adds ANSI
logging back to the asana tools.