### PR TITLE
Ignore unassigned stories

### DIFF
--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -36,7 +36,7 @@ main = do
       when (isNothing sCost) . logWarn $ "Story is not costed: " <> display url
       case sAssignee of
         Nothing -> do
-          logWarn $ "Story's has no assignee: " <> display url
+          logWarn $ "Story has no assignee: " <> display url
           pure Nothing
         Just _ -> mayCanDo story
 


### PR DESCRIPTION
Stories that lack an assignee should be ignored in velocity
calculations. This helps for teams that use the primary backlog instead
of individual boards.

- Throws a warning when a story is missing an assignee
- Removes that story from the velocity calculation
- Moves to using `catMaybes` so a variety of conditions can be handled
  with `Nothing`.