### PR TITLE
Ignore section tasks

### DIFF
--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -28,20 +28,23 @@ data Story = Story
   }
   deriving Show
 
-fromTask :: Task -> Story
-fromTask Task {..} = Story
-  { sAssignee = tAssignee
-  , sName = tName
-  , sCompleted = tCompleted || awaitingDeployment
-  , sCompletedAt = tCompletedAt
-  , sCost = findNumber "cost" tCustomFields
-  , sImpact = findNumber "impact" tCustomFields
-  , sVirality = findNumber "virality" tCustomFields
-  , sCarryOver = findNumber "carryover" tCustomFields
-  , sCanDo = findYesNo "can do?" tCustomFields
-  , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
-  , sId = tId
-  }
+fromTask :: Task -> Maybe Story
+fromTask Task {..} = case tResourceSubtype of
+  Milestone -> Nothing
+  Section -> Nothing
+  DefaultTask -> Just $ Story
+    { sAssignee = tAssignee
+    , sName = tName
+    , sCompleted = tCompleted || awaitingDeployment
+    , sCompletedAt = tCompletedAt
+    , sCost = findNumber "cost" tCustomFields
+    , sImpact = findNumber "impact" tCustomFields
+    , sVirality = findNumber "virality" tCustomFields
+    , sCarryOver = findNumber "carryover" tCustomFields
+    , sCanDo = findYesNo "can do?" tCustomFields
+    , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
+    , sId = tId
+    }
  where
   awaitingDeployment = flip any tMemberships $ \Membership {..} ->
     case mSection of

--- a/package.yaml
+++ b/package.yaml
@@ -60,6 +60,7 @@ executables:
     dependencies:
       - asana
       - rio
+      - transformers
   debt-evaluation:
     main: Main.hs
     source-dirs: debt-evaluation


### PR DESCRIPTION
Section tasks never represent a story. They should not be included in
any story based calculation. This is determined by looking at the
`resourece_subtype` of the task. Only `default_task` types should be
included. This pushes some `Maybe` behavior into all the executables,
but it is an easy situation to overcome.