### PR TITLE
Migrate to Global Unique IDs

### DIFF
--- a/bug-reproduction/Main.hs
+++ b/bug-reproduction/Main.hs
@@ -41,7 +41,7 @@ main = do
     let
       accumulateStory :: Totals -> Named -> AppM Totals
       accumulateStory totals named = do
-        mStory <- fromTask <$> getTask (nId named)
+        mStory <- fromTask <$> getTask (nGid named)
         case mStory of
           Nothing -> pure mempty
           Just story@Story {..} -> do

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -22,7 +22,7 @@ main = do
       processStories =
         fmap catMaybes . pooledForConcurrentlyN maxRequests tasks
     stories <- processStories $ \Named {..} -> do
-      mStory <- fromTask <$> getTask nId
+      mStory <- fromTask <$> getTask nGid
       for mStory $ \story@Story {..} -> do
         let url = "<" <> storyUrl projectId story <> ">"
         logInfo . display $ url <> " " <> sName

--- a/library/Asana/Api/Gid.hs
+++ b/library/Asana/Api/Gid.hs
@@ -1,0 +1,15 @@
+-- | A globally unique identifier
+module Asana.Api.Gid
+    ( Gid
+    , gidToText
+    ) where
+
+import RIO
+
+import Data.Aeson
+import RIO.Text (Text)
+
+newtype Gid = Gid { gidToText :: Text }
+  deriving (Eq, Generic, Show)
+  deriving newtype (FromJSON, ToJSON)
+

--- a/library/Asana/Api/Named.hs
+++ b/library/Asana/Api/Named.hs
@@ -5,12 +5,13 @@ module Asana.Api.Named
 
 import RIO
 
+import Asana.Api.Gid (Gid)
 import Data.Aeson
 import Data.Aeson.Casing
 import RIO.Text (Text)
 
 data Named = Named
-  { nId :: Integer
+  { nGid :: Gid
   , nName :: Text
   }
   deriving (Eq, Generic, Show)

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -7,6 +7,7 @@ module Asana.Story
 import RIO
 
 import Asana.Api
+import Asana.Api.Gid (Gid, gidToText)
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Semigroup ((<>))
 import RIO.Text (Text)
@@ -24,7 +25,7 @@ data Story = Story
   , sCarryOver :: Maybe Integer
   , sCanDo :: Maybe Bool
   , sReproduced :: Maybe Bool
-  , sId :: Int
+  , sGid :: Gid
   }
   deriving Show
 
@@ -43,7 +44,7 @@ fromTask Task {..} = case tResourceSubtype of
     , sCarryOver = findNumber "carryover" tCustomFields
     , sCanDo = findYesNo "can do?" tCustomFields
     , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
-    , sId = tId
+    , sGid = tGid
     }
  where
   awaitingDeployment = flip any tMemberships $ \Membership {..} ->
@@ -70,4 +71,4 @@ caseFoldEq x y = T.toCaseFold x == T.toCaseFold y
 
 storyUrl :: Text -> Story -> Text
 storyUrl projectId Story {..} =
-  "https://app.asana.com/0/" <> projectId <> "/" <> T.pack (show sId) <> "/f"
+  "https://app.asana.com/0/" <> projectId <> "/" <> gidToText sGid <> "/f"

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -23,7 +23,7 @@ main = do
         fmap catMaybes . pooledForConcurrentlyN maxRequests tasks
 
     stories <- processStories $ \Named {..} -> runMaybeT $ do
-      story@Story {..} <- MaybeT $ fromTask <$> getTask nId
+      story@Story {..} <- MaybeT $ fromTask <$> getTask nGid
       let url = "<" <> storyUrl projectId story <> ">"
       MaybeT $ do
         logInfo . display $ url <> " " <> sName


### PR DESCRIPTION
Asana is attempting to migrate to globally unique identifiers. As such
they have boxed all their existing integer identifiers as strings and
placed them under a `gid` property. These identifiers should work in all
places that they currently work, so most of this is just mechanically
switching from `Integer` to `Gid` newtype.

https://asana.com/developers/documentation/getting-started/deprecations