### PR TITLE
Clarify close-iteration output

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -50,24 +50,46 @@ main = do
       incompleteCost = sum $ mapMaybe sCost incompleteStories
       incompleteCarryOver = sum $ mapMaybe sCarryOver incompleteStories
 
+      completedWithCarry = completedCost + completedCarryOver
+
+      totalCompletedCost =
+        sum [completedWithCarry, incompleteCost - incompleteCarryOver]
+
+      totalCommittedCost = sum [completedWithCarry, incompleteCost]
+
+      storiesCompletedWithCarry =
+        length completedStories + length carriedStories
+
     hPutBuilder stdout . getUtf8Builder $ foldMap
       (<> "\n")
       [ ""
-      , "Completed"
-      , "- new points: " <> display completedCost
-      , "- carried over points: " <> display completedCarryOver
-      , "- new stories: " <> display (length completedStories)
-      , "- carried over stories: " <> display (length carriedStories)
-      , "Incomplete"
-      , "- points completed: " <> display (incompleteCost - incompleteCarryOver)
-      , "- carry over points: " <> display incompleteCarryOver
-      , "- carry over stories: " <> display (length incompleteStories)
+      , "Completed points: "
+      <> display completedWithCarry
+      <> " ("
+      <> display completedCarryOver
+      <> " were carry-over)"
+      , "Completed tasks: "
+      <> display storiesCompletedWithCarry
+      <> " ("
+      <> display (length carriedStories)
+      <> " were carry-over)"
       , ""
-      , display
-        (completedCost
-        + completedCarryOver
-        + (incompleteCost - incompleteCarryOver)
-        )
-      <> " / "
-      <> display (completedCost + completedCarryOver + incompleteCost)
+      , "Incomplete points: " <> display incompleteCarryOver
+      , "Incomplete tasks: "
+      <> display (length incompleteStories)
+      <> " ("
+      <> display incompleteCost
+      <> " total cost)"
+      , ""
+      , "Velocity: "
+      <> display totalCompletedCost
+      <> "/"
+      <> display totalCommittedCost
+      <> " ("
+      <> display (velocity totalCompletedCost totalCommittedCost)
+      <> "%)"
       ]
+
+velocity :: Integer -> Integer -> Double
+velocity completed committed =
+  (fromIntegral completed / fromIntegral committed) * 100

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -51,8 +51,9 @@ main = do
       incompleteCarryOver = sum $ mapMaybe sCarryOver incompleteStories
 
     hPutBuilder stdout . getUtf8Builder $ foldMap
-      ("\n" <>)
-      [ "Completed"
+      (<> "\n")
+      [ ""
+      , "Completed"
       , "- new points: " <> display completedCost
       , "- carried over points: " <> display completedCarryOver
       , "- new stories: " <> display (length completedStories)

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -52,7 +52,6 @@ main = do
 
       totalCompletedCost =
         sum [completedCostCarried, completedCostNew, completedCostPartial]
-      totalCommittedCost = sum [totalCompletedCost, incompleteCarryOver]
 
     hPutBuilder stdout . getUtf8Builder $ foldMap
       (<> "\n")
@@ -84,16 +83,4 @@ main = do
       <> " (worth "
       <> display incompleteCost
       <> " total)"
-      , ""
-      , "Velocity: "
-      <> display totalCompletedCost
-      <> "/"
-      <> display totalCommittedCost
-      <> " ("
-      <> display (velocity totalCompletedCost totalCommittedCost)
-      <> "%)"
       ]
-
-velocity :: Integer -> Integer -> Double
-velocity completed committed =
-  (fromIntegral completed / fromIntegral committed) * 100


### PR DESCRIPTION
I found the previous output hard to understand:

```
Completed
- new points: 19
- carried over points: 14
- new stories: 13
- carried over stories: 17
Incomplete
- points completed: 11
- carry over points: 22
- carry over stories: 14

44 / 66
```

Some of my confusions:

- What does "new" mean?
- Does "carried over" mean into our out of the closing iteration?
- Ditto "carry over"
- How does "Incomplete" have "completed" points?
- is "44 / 66" velocity? Why make me do the math?

The new output is this:

```
Completed points: 33 (14 were carry-over)
Completed tasks: 30 (17 were carry-over)

Incomplete points: 22
Incomplete tasks: 14 (33 total cost)

Velocity: 44/66 (66.66666666666666%)
```

This attempts to clarify:

- That we're showing totals and breaking out what was carried
- Past tense when talking about carried into the iteration
- How we get credit for partial points, but show total incomplete too

And computes velocity for you.

Also included:

f99bd76 Ensure trailing newline in output

The fold was placing a leading newline, desired to separate the totals from the
logging above. It did not include a trailing newline, which messes up my prompt
when the tool is run.

We could explicitly do that, but it was easier to switch the fold to place
trailing newlines (including a final one) and then have an explicitly empty
first element in our list of lines.