### PR TITLE
Add cycle time measure

### DIFF
--- a/cycle-time/Main.hs
+++ b/cycle-time/Main.hs
@@ -1,0 +1,107 @@
+-- | A tool for measuring cycle time of tasks
+--
+-- Cycle time is the difference between creation date and completion date.
+--
+module Main (main) where
+
+import RIO
+
+import Asana.Api
+import Asana.Api.Gid (gidToText, textToGid)
+import Asana.Api.Project (Project(pCreatedAt, pGid, pName), getProjects)
+import Asana.App (loadApp, runApp)
+import Control.Monad (when)
+import Data.Csv as Csv
+import Data.Foldable (maximum, minimum)
+import Data.List (intercalate, nub)
+import qualified Data.Vector as V
+import RIO.ByteString (writeFile)
+import RIO.ByteString.Lazy (toStrict)
+import RIO.Text (isPrefixOf)
+import RIO.Time (NominalDiffTime, diffUTCTime, toGregorian, utctDay)
+import Statistics.Quantile (median, medianUnbiased)
+import Statistics.Sample (kurtosis, mean, skewness, stdDev)
+import Statistics.Sample.Histogram (histogram)
+import System.IO.Temp (emptySystemTempFile)
+import Text.Printf (printf)
+
+main :: IO ()
+main = do
+  app <- loadApp
+  runApp app $ do
+    logDebug "Fetch projects"
+    projects <- filter approvedProject <$> getProjects
+
+    taskGids <-
+      fmap (nub . concat)
+      . pooledForConcurrentlyN maxRequests projects
+      $ \project -> do
+          logDebug . fromString $ "Project tasks: " <> show
+            (gidToText $ pGid project)
+          fmap nGid <$> getProjectTasks (pGid project) AllTasks
+    bugTaskGids <-
+      fmap nGid <$> getProjectTasks (textToGid "56224185180675") AllTasks
+
+    let nonBugGids = filter (`notElem` bugTaskGids) taskGids
+
+    cycleTimes <-
+      zscoreFilter
+      . V.fromList
+      . fmap realToFrac
+      . mapMaybe mayCycleTime
+      <$> pooledForConcurrentlyN maxRequests nonBugGids getTask
+
+    when (null cycleTimes) $ logWarn "No cycle time to compute"
+
+    logDebug "Write histogram CSV"
+    filePath <- liftIO $ emptySystemTempFile ".csv"
+    let histogramCsv = uncurry V.zip $ histogram @_ @_ @Double 100 cycleTimes
+    writeFile filePath . toStrict . Csv.encode $ V.toList histogramCsv
+    logInfo . fromString $ "Histogram written to " <> filePath
+
+    logDebug "Display Cycle Time"
+    let
+      fmt = intercalate
+        "\n"
+        [ "Cycle Time"
+        , "- mean:     %d days"
+        , "- mediam:   %d days"
+        , "- skewness: %.3f"
+        , "- kurtosis: %.3f"
+        , "- stdDev:   %d days"
+        , "- max:      %d days"
+        , "- min:      %d days"
+        ]
+    logInfo . fromString $ printf
+      fmt
+      (toDays $ mean cycleTimes)
+      (toDays $ median medianUnbiased cycleTimes)
+      (skewness cycleTimes)
+      (kurtosis cycleTimes)
+      (toDays $ stdDev cycleTimes)
+      (toDays $ maximum cycleTimes)
+      (toDays $ minimum cycleTimes)
+
+zscoreFilter :: Vector Double -> Vector Double
+zscoreFilter p =
+  let
+    av = mean p
+    sdev = stdDev p
+    zs x = (x - av) / sdev
+  in V.filter ((<= 3) . zs) p
+
+toDays :: Double -> Int
+toDays = floor . (/ 86400)
+
+approvedProject :: Project -> Bool
+approvedProject project = year == 2018 && isPrefixOf
+  "Iteration"
+  (pName project)
+  where (year, _, _) = toGregorian $ utctDay (pCreatedAt project)
+
+mayCycleTime :: Task -> Maybe NominalDiffTime
+mayCycleTime task = do
+  completedAt <- tCompletedAt task
+  -- FIXME: Sometimes this is true
+  guard $ completedAt > tCreatedAt task
+  Just . diffUTCTime completedAt $ tCreatedAt task

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -66,6 +66,7 @@ data Task = Task
   , tName :: Text
   , tCompleted :: Bool
   , tCompletedAt :: Maybe UTCTime
+  , tCreatedAt :: UTCTime
   , tCustomFields :: [CustomField]
   , tMemberships :: [Membership]
   , tGid :: Gid

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -44,7 +44,7 @@ data App = App
   }
 
 instance HasLogFunc App where
-  logFuncL = lens logFunc (\app logFunc -> app {logFunc})
+  logFuncL = lens logFunc (\app logFunc -> app { logFunc })
 
 data Perspective = Pessimistic | Optimistic
 

--- a/package.yaml
+++ b/package.yaml
@@ -67,3 +67,13 @@ executables:
     dependencies:
       - asana
       - rio
+  cycle-time:
+    main: Main.hs
+    source-dirs: cycle-time
+    dependencies:
+      - asana
+      - cassava
+      - rio
+      - statistics
+      - temporary
+      - vector

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.29
+resolver: lts-14.20
 packages:
 - .
 # NB. -fignore-optim-changes can get in the way of profiling projects. To

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 500539
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/29.yaml
-    sha256: 006398c5e92d1d64737b7e98ae4d63987c36808814504d1451f56ebd98093f75
-  original: lts-13.29
+    size: 524154
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/20.yaml
+    sha256: 2f5099f69ddb6abfe64400fe1e6a604e8e628f55e6837211cd70a81eb0a8fa4d
+  original: lts-14.20


### PR DESCRIPTION
Product level cycle time is an important metric to keep an eye on. How
quickly we are able to iterate on ideas and ship them to production for
validation says a lot about how nimble we are as an organization. Large
regressions in these numbers may indicate shifts in business priority,
breakdowns in process or other maladaptations.

This executable is an experimental tool to measure that from Asana task
lifetime. This does not capture the entire cycle time of a product idea
from inception to shipping, but it gives us a rough estimate from
business processes we can observe and measure.
