### PR TITLE
Specify extension arguments for given executables

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import RIO
 
 import Asana.Api
+import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
 import Control.Monad (when)
@@ -10,12 +11,17 @@ import Data.List (partition)
 import Data.Maybe (isJust, isNothing, mapMaybe)
 import Data.Semigroup ((<>))
 
+data AppExt = AppExt
+  { appProjectId :: Gid
+  , appPerspective :: Perspective
+  }
+
 main :: IO ()
 main = do
-  app <- loadApp
+  app <- loadAppWith $ AppExt <$> parseProjectId <*> parsePessimistic
   runApp app $ do
-    projectId <- asks appProjectId
-    perspective <- asks appPerspective
+    projectId <- asks $ appProjectId . appExt
+    perspective <- asks $ appPerspective . appExt
     tasks <- getProjectTasks projectId AllTasks
 
     let

--- a/debt-evaluation/Main.hs
+++ b/debt-evaluation/Main.hs
@@ -33,6 +33,10 @@ import Data.Maybe (mapMaybe)
 import RIO.Text (Text)
 import Text.Printf (printf)
 
+newtype AppExt = AppExt
+  { appProjectId :: Gid
+  }
+
 data Point = Point
   { pGid :: Gid
   , pUrl :: Text
@@ -61,9 +65,9 @@ data Priority
 
 main :: IO ()
 main = do
-  app <- loadApp
+  app <- loadAppWith $ AppExt <$> parseProjectId
   runApp app $ do
-    projectId <- asks appProjectId
+    projectId <- asks $ appProjectId . appExt
 
     logDebug "Fetch stories"
     tasks <- getProjectTasks projectId IncompletedTasks

--- a/library/Asana/Api/Project.hs
+++ b/library/Asana/Api/Project.hs
@@ -24,7 +24,7 @@ data Project = Project
 instance FromJSON Project where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
 
-getProjects :: AppM [Project]
+getProjects :: AppM ext [Project]
 getProjects = getAllParams
   (T.unpack "/projects/")
   [("team", "12760955045995"), ("opt_fields", "created_at,name")]

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -78,7 +78,7 @@ instance FromJSON Task where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
 
 -- | Return all details for a task by id
-getTask :: Gid -> AppM Task
+getTask :: Gid -> AppM ext Task
 getTask taskId = getSingle $ "/tasks/" <> T.unpack (gidToText taskId)
 
 -- | Return compact task details for a project
@@ -87,7 +87,7 @@ getTask taskId = getSingle $ "/tasks/" <> T.unpack (gidToText taskId)
 -- precludes us logging things each time we request an element. So we return
 -- @'Named'@ for now and let the caller use @'getTask'@ themselves.
 --
-getProjectTasks :: Gid -> TaskStatusFilter -> AppM [Named]
+getProjectTasks :: Gid -> TaskStatusFilter -> AppM ext [Named]
 getProjectTasks projectId taskStatusFilter = do
   now <- liftIO getCurrentTime
   getAllParams
@@ -103,12 +103,12 @@ formatISO8601 = formatTime defaultTimeLocale (iso8601DateFormat Nothing)
 
 data TaskStatusFilter = IncompletedTasks | AllTasks
 
-getProjectTasksCompletedSince :: Gid -> UTCTime -> AppM [Named]
+getProjectTasksCompletedSince :: Gid -> UTCTime -> AppM ext [Named]
 getProjectTasksCompletedSince projectId since = getAllParams
   (T.unpack $ "/projects/" <> gidToText projectId <> "/tasks")
   [("completed_since", formatISO8601 since)]
 
-putEnumField :: Gid -> (Integer, Maybe Integer) -> AppM ()
+putEnumField :: Gid -> (Integer, Maybe Integer) -> AppM ext ()
 putEnumField taskId (fieldId, enumId) =
   put ("/tasks/" <> T.unpack (gidToText taskId)) $ object
     [ "data"


### PR DESCRIPTION
Some executables do not require a `project` others do not react to
`pessimistic` arguments. The `App` type is bloated with unnecessary
arguments. Instead these arguments have been pulled down to the
executable level using `loadAppWith`.