### PR TITLE
Don't warn about carry on zero point tasks

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -33,7 +33,9 @@ main = do
         let url = "<" <> storyUrl projectId story <> ">"
         logInfo . display $ url <> " " <> sName
 
-        let incompleteNoCarry = not sCompleted && isNothing sCarryOver
+        let
+          incompleteNoCarry =
+            not sCompleted && isNothing sCarryOver && maybe True (> 0) sCost
         when incompleteNoCarry
           $ logWarn
           $ "No carry over on incomplete story: "


### PR DESCRIPTION
Story tasks are often marked as zero points. Having warnings on these
tasks just adds noise to the log output. Instead we should silence
warnings in this situation.