### PR TITLE
Add planningpoker.com import/export

### DIFF
--- a/library/Asana/Api/Gid.hs
+++ b/library/Asana/Api/Gid.hs
@@ -12,7 +12,7 @@ import RIO.Text (Text)
 
 newtype Gid = Gid { gidToText :: Text }
   deriving (Eq, Generic, Show)
-  deriving newtype (FromJSON, ToJSON)
+  deriving newtype (FromJSON, ToJSON, Hashable)
 
 textToGid :: Text -> Gid
 textToGid = Gid

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -136,6 +136,7 @@ data Task = Task
   , tMemberships :: [Membership]
   , tGid :: Gid
   , tResourceSubtype :: ResourceSubtype
+  , tNotes :: Text
   }
   deriving (Eq, Generic, Show)
 

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -17,6 +17,7 @@ module Asana.App
   , parseProjectId
   , parseBugProjectId
   , parseYear
+  , parseImport
   ) where
 
 import RIO
@@ -109,3 +110,6 @@ parseBugProjectId =
 
 parseYear :: Parser Integer
 parseYear = option auto (long "year" <> help "The year to view")
+
+parseImport :: Parser (Maybe FilePath)
+parseImport = optional (strOption (long "import" <> help "CSV File to import"))

--- a/package.yaml
+++ b/package.yaml
@@ -91,9 +91,7 @@ executables:
     source-dirs: planning-poker
     dependencies:
       - asana
-      - optparse-applicative
       - rio
       - text
-      - transformers
       - cassava
       - safe

--- a/package.yaml
+++ b/package.yaml
@@ -86,3 +86,14 @@ executables:
       - optparse-applicative
       - rio
       - text
+  planning-poker:
+    main: Main.hs
+    source-dirs: planning-poker
+    dependencies:
+      - asana
+      - optparse-applicative
+      - rio
+      - text
+      - transformers
+      - cassava
+      - safe

--- a/planning-poker/Main.hs
+++ b/planning-poker/Main.hs
@@ -148,7 +148,13 @@ instance DefaultOrdered PlanningPokerTask where
 fetchPlanningPokerTask :: Named -> AppM ext PlanningPokerTask
 fetchPlanningPokerTask Named {..} = do
   task@Task {..} <- getTask nGid
-  pure $ PlanningPokerTask tGid tName tNotes "" $ extractCost task
+  pure $ PlanningPokerTask
+    { issueKey = tGid
+    , summary = tName
+    , description = tNotes
+    , acceptanceCriteria = ""
+    , storyPoints = extractCost task
+    }
 
 extractCost :: Task -> Maybe Integer
 extractCost t = extractCostField t >>= \case

--- a/planning-poker/Main.hs
+++ b/planning-poker/Main.hs
@@ -1,0 +1,161 @@
+module Main (main) where
+
+import RIO
+
+import Asana.Api
+import Asana.Api.Gid
+import Asana.App
+import Data.Csv
+import qualified RIO.ByteString.Lazy as RBSL
+import qualified RIO.HashMap as HashMap
+import qualified RIO.Text as T
+import Safe (headMay)
+
+data AppExt = AppExt
+  { appProjectId :: Gid
+  , appImport :: Maybe FilePath
+  }
+
+main :: IO ()
+main = do
+  app <- loadAppWith $ AppExt <$> parseProjectId <*> parseImport
+  runApp app $ do
+    AppExt {..} <- asks appExt
+    case appImport of
+      Nothing -> exportProjectTasks appProjectId
+      Just file -> importProjectTasksFromFile file appProjectId
+
+exportProjectTasks :: Gid -> AppM AppExt ()
+exportProjectTasks projectId = do
+  projectTasks <- getProjectTasks projectId AllTasks
+  tasks <- pooledForConcurrentlyN
+    maxRequests
+    projectTasks
+    fetchPlanningPokerTask
+  liftIO
+    . RBSL.writeFile "planning-poker-export.csv"
+    $ encodeDefaultOrderedByName tasks
+
+importProjectTasksFromFile :: FilePath -> Gid -> AppM AppExt ()
+importProjectTasksFromFile file projectId = do
+  contents <- RBSL.readFile file
+  case decodeByName contents of
+    Left err -> logError $ fromString err
+    Right (_, tasks) -> do
+      projectTaskGids <- map nGid <$> getProjectTasks projectId AllTasks
+      projectTasks <- pooledForConcurrentlyN maxRequests projectTaskGids getTask
+      let projectTaskMap = HashMap.fromList $ map (tGid &&& id) projectTasks
+
+      void $ pooledForConcurrentlyN
+        maxRequests
+        tasks
+        (updatePlanningPokerTaskCost projectTaskMap)
+
+updatePlanningPokerTaskCost
+  :: HashMap Gid Task -> PlanningPokerTask -> AppM AppExt ()
+updatePlanningPokerTaskCost projectTaskMap planningPokerTask@PlanningPokerTask {..}
+  = case storyPoints of
+    Nothing -> logInfo $ planningPokerTaskLog
+      planningPokerTask
+      "Does not have a cost. Skipping import."
+    Just cost -> case HashMap.lookup issueKey projectTaskMap of
+      Nothing -> logWarn $ planningPokerTaskLog
+        planningPokerTask
+        "Not found in project. Skipping import."
+
+      Just task@Task {..} -> case extractCostField task of
+        Just (CustomNumber costFieldGid _ _) -> do
+          putCustomField tGid $ CustomNumber costFieldGid "cost" (Just cost)
+
+          logInfo
+            $ planningPokerTaskLog planningPokerTask
+            $ "cost was updated to "
+            <> T.pack (show cost)
+
+        _ -> logWarn $ planningPokerTaskLog
+          planningPokerTask
+          "No 'cost' field.  Skipping import."
+
+planningPokerTaskLog :: PlanningPokerTask -> T.Text -> Utf8Builder
+planningPokerTaskLog task message =
+  fromText
+    $ "Task \""
+    <> planningPokerSummaryFromTaskLink task
+    <> "\" <"
+    <> planningPokerTaskUrl task
+    <> ">: "
+    <> message
+
+fromText :: Text -> Utf8Builder
+fromText = fromString . T.unpack
+
+data PlanningPokerTask = PlanningPokerTask
+  { issueKey :: Gid
+  , summary :: Text
+  , description :: Text
+  , acceptanceCriteria :: Text
+  , storyPoints :: Maybe Integer
+  }
+  deriving stock (Show)
+
+instance FromNamedRecord PlanningPokerTask where
+  parseNamedRecord m =
+    PlanningPokerTask
+      <$> (textToGid <$> m .: "Issue Key")
+      <*> m
+      .: "Summary"
+      <*> m
+      .: "Description"
+      <*> m
+      .: "Acceptance Criteria"
+      <*> m
+      .: "Story Points"
+
+instance ToNamedRecord PlanningPokerTask where
+  toNamedRecord task@PlanningPokerTask {..} = namedRecord
+    [ "Issue Key" .= toField (gidToText issueKey)
+    , "Summary" .= toField (planningPokerTaskLink task)
+    , "Description" .= toField description
+    , "Acceptance Criteria" .= toField acceptanceCriteria
+    , "Story Points" .= toField storyPoints
+    ]
+
+planningPokerTaskLink :: PlanningPokerTask -> T.Text
+planningPokerTaskLink task@PlanningPokerTask {..} =
+  "<a href='" <> planningPokerTaskUrl task <> "'> " <> summary <> "</a>"
+
+-- | Undo formatting of planning poker task link to extract summary
+planningPokerSummaryFromTaskLink :: PlanningPokerTask -> T.Text
+planningPokerSummaryFromTaskLink task@PlanningPokerTask {..} =
+  dropLast 4 $ T.drop
+    (T.length $ "<a href='" <> planningPokerTaskUrl task <> "'> ")
+    summary
+  where dropLast n t = T.take (T.length t - n) t
+
+planningPokerTaskUrl :: PlanningPokerTask -> T.Text
+planningPokerTaskUrl PlanningPokerTask {..} =
+  "https://app.asana.com/0/0/" <> gidToText issueKey <> "/f"
+
+instance DefaultOrdered PlanningPokerTask where
+  headerOrder _ = header
+    [ "Issue Key"
+    , "Summary"
+    , "Description"
+    , "Acceptance Criteria"
+    , "Story Points"
+    ]
+
+fetchPlanningPokerTask :: Named -> AppM ext PlanningPokerTask
+fetchPlanningPokerTask Named {..} = do
+  task@Task {..} <- getTask nGid
+  pure $ PlanningPokerTask tGid tName tNotes "" $ extractCost task
+
+extractCost :: Task -> Maybe Integer
+extractCost t = extractCostField t >>= \case
+  CustomNumber _ _ mCost -> mCost
+  _ -> Nothing
+
+extractCostField :: Task -> Maybe CustomField
+extractCostField Task {..} = headMay $ flip mapMaybe tCustomFields $ \case
+  customField@(CustomNumber _ "cost" _) -> Just customField
+  _ -> Nothing


### PR DESCRIPTION
Exposes an interface for CSV import/export to/from planningpoker.com. The
process for using this is as such:

1. `planning-poker --project blah` # Export to 'planning-poker-export.csv'
2. Set up a planningpoker.com game using 'planning-poker-export.csv' for
   stories
3. Go through planning poker session
4. Export results as csv to file 'planning-poker-import.csv'
5. `planning-poker --project blah --import planning-poker-import.csv`