### PR TITLE
Custom numeric fields can be fractional; use Scientific, not Integer

### DIFF
--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -37,6 +37,7 @@ import Data.Aeson
   )
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
 import Data.List (find)
+import Data.Scientific (Scientific)
 import Data.Semigroup ((<>))
 import RIO.Text (Text)
 import qualified RIO.Text as T
@@ -51,7 +52,7 @@ import RIO.Time
 
 -- | Just what we need out of our @custom_fields@ for cost and carry-over
 data CustomField
-  = CustomNumber Gid Text (Maybe Integer)
+  = CustomNumber Gid Text (Maybe Scientific)
   | CustomEnum Gid Text [EnumOption] (Maybe Text)
   | Other -- ^ Unexpected types dumped here
   deriving (Eq, Generic, Show)

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -9,6 +9,7 @@ import RIO
 import Asana.Api
 import Asana.Api.Gid (Gid, gidToText)
 import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Scientific (Scientific)
 import Data.Semigroup ((<>))
 import RIO.Text (Text)
 import qualified RIO.Text as T
@@ -38,10 +39,10 @@ fromTask Task {..} = case tResourceSubtype of
     , sName = tName
     , sCompleted = tCompleted || awaitingDeployment
     , sCompletedAt = tCompletedAt
-    , sCost = findNumber "cost" tCustomFields
-    , sImpact = findNumber "impact" tCustomFields
-    , sVirality = findNumber "virality" tCustomFields
-    , sCarryOver = findNumber "carryover" tCustomFields
+    , sCost = findInteger "cost" tCustomFields
+    , sImpact = findInteger "impact" tCustomFields
+    , sVirality = findInteger "virality" tCustomFields
+    , sCarryOver = findInteger "carryover" tCustomFields
     , sCanDo = findYesNo "can do?" tCustomFields
     , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
     , sGid = tGid
@@ -52,7 +53,10 @@ fromTask Task {..} = case tResourceSubtype of
       Just Named {..} | caseFoldEq nName "Awaiting Deployment" -> True
       _ -> False
 
-findNumber :: Text -> [CustomField] -> Maybe Integer
+findInteger :: Text -> [CustomField] -> Maybe Integer
+findInteger field = fmap round . findNumber field
+
+findNumber :: Text -> [CustomField] -> Maybe Scientific
 findNumber field = listToMaybe . mapMaybe cost
  where
   cost = \case

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ library:
     - load-env
     - optparse-applicative
     - rio
+    - scientific
 
 executables:
   bug-reproduction:

--- a/planning-poker/Main.hs
+++ b/planning-poker/Main.hs
@@ -65,7 +65,7 @@ updatePlanningPokerTaskCost projectTaskMap planningPokerTask@PlanningPokerTask {
 
       Just task@Task {..} -> case extractCostField task of
         Just (CustomNumber costFieldGid _ _) -> do
-          putCustomField tGid $ CustomNumber costFieldGid "cost" (Just cost)
+          putCustomField tGid $ CustomNumber costFieldGid "cost" (Just $ fromIntegral cost)
 
           logInfo
             $ planningPokerTaskLog planningPokerTask
@@ -158,7 +158,7 @@ fetchPlanningPokerTask Named {..} = do
 
 extractCost :: Task -> Maybe Integer
 extractCost t = extractCostField t >>= \case
-  CustomNumber _ _ mCost -> mCost
+  CustomNumber _ _ mCost -> round <$> mCost
   _ -> Nothing
 
 extractCostField :: Task -> Maybe CustomField


### PR DESCRIPTION
I was trying to run `start-iteration` and I got:

```plaintext
parsing Integer failed, unexpected floating number 0.18
```

It turns out custom numeric fields can be fractional. Here, `PercentStudents` field is stored as `0.18` ([task](https://app.asana.com/0/1169465618172456/1170570480126996)):

![image](https://user-images.githubusercontent.com/592078/79372161-722a5980-7f0a-11ea-88ae-8a947385d48e.png)

I changed our `CustomNumber` constructor to use `Scientific` instead of `Integer`:

```diff
 data CustomField
-  = CustomNumber Gid Text (Maybe Integer)
+  = CustomNumber Gid Text (Maybe Scientific)
   | CustomEnum Gid Text [EnumOption] (Maybe Text)
   | Other -- ^ Unexpected types dumped here
```

Alternatively, we could make whatever's filling in that field use whole numbers. Either works for me, though I'm sure we'll run into this again.