### PR TITLE
Add capitalized cost

### DIFF
--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -26,6 +26,7 @@ data Story = Story
   , sCarryOver :: Maybe Integer
   , sCanDo :: Maybe Bool
   , sReproduced :: Maybe Bool
+  , sCapitalized :: Bool
   , sGid :: Gid
   }
   deriving Show
@@ -45,6 +46,7 @@ fromTask Task {..} = case tResourceSubtype of
     , sCarryOver = findInteger "carryover" tCustomFields
     , sCanDo = findYesNo "can do?" tCustomFields
     , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
+    , sCapitalized = fromMaybe False $ findYesNo "cap?" tCustomFields
     , sGid = tGid
     }
  where
@@ -68,7 +70,7 @@ findYesNo x = fmap parse . listToMaybe . mapMaybe go
  where
   go (CustomEnum _ name _ mn) | caseFoldEq name x = mn
   go _ = Nothing
-  parse = (== "Yes")
+  parse str = str == "Yes" || str == "Y"
 
 caseFoldEq :: Text -> Text -> Bool
 caseFoldEq x y = T.toCaseFold x == T.toCaseFold y


### PR DESCRIPTION
We are trying a new strategy to capitalize our development. Individual
tasks will be marked as capitalized or not. At the end of the iteration
the total velocity calculation will also include a sub calculation of
the completed capitalized work.

This commit:
- Adds `sCapitalized` to the `Story` data type. It defaults to `False`.
- We need to duplicate stat calculations for capitalized stories. The
  printing of stats and calculation of stats has been decoupled with the
  `CompletionStats` data type.

Confluence doc on Capitalized cost: https://renaissancelearning.atlassian.net/wiki/spaces/AD/pages/628884013/Iteration+Closeout