### PR TITLE
Various close-iteration improvements

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -74,7 +74,7 @@ updateCompletedPoints :: Gid -> [Task] -> AppM AppExt ()
 updateCompletedPoints projectId tasks =
   pooledForConcurrentlyN_ maxRequests tasks $ \task -> do
     let mStory = fromTask task
-    for_ mStory $ \story@(Story {..}) -> do
+    for_ mStory $ \story@Story {..} -> do
       let
         mCompletedPoints = case (sCompleted, sCarryIn, sCarryOut) of
           (True, Nothing, _) -> sCost

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -38,7 +38,8 @@ main = do
         let
           incompleteNoCarry =
             not sCompleted
-              && (isNothing sCarryOver && isNothing sCarryOut)
+              && isNothing sCarryOver
+              && isNothing sCarryOut
               && maybe True (> 0) sCost
 
         when incompleteNoCarry
@@ -79,7 +80,7 @@ updateCompletedPoints projectId tasks =
         mCompletedPoints = case (sCompleted, sCarryIn, sCarryOut) of
           (True, Nothing, _) -> sCost
           (True, Just carryIn, _) -> Just carryIn
-          (False, _, Just carryOut) -> (-) <$> sCost <*> Just carryOut
+          (False, _, Just carryOut) -> subtract carryOut <$> sCost
           _ -> Nothing
 
       case mCompletedPoints of

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NamedFieldPuns #-}
+
 
 module Main (main) where
 
@@ -9,9 +9,12 @@ import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
 import Control.Monad (when)
-import Data.List (partition)
-import Data.Maybe (isJust, isNothing, mapMaybe)
-import Data.Semigroup ((<>))
+import Data.Char (toLower)
+import Data.Maybe (isJust, isNothing)
+import Data.Semigroup (Sum(..), (<>))
+import Data.Semigroup.Generic (gmappend, gmempty)
+import Safe (headMay)
+import System.IO (getLine, putStr)
 
 data AppExt = AppExt
   { appProjectId :: Gid
@@ -24,20 +27,22 @@ main = do
   runApp app $ do
     projectId <- asks $ appProjectId . appExt
     perspective <- asks $ appPerspective . appExt
-    tasks <- getProjectTasks projectId AllTasks
+    projectTasks <- getProjectTasks projectId AllTasks
 
-    let
-      processStories =
-        fmap catMaybes . pooledForConcurrentlyN maxRequests tasks
-    stories <- processStories $ \Named {..} -> do
-      mStory <- fromTask <$> getTask nGid
+    tasks <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
+
+    stories <- fmap catMaybes . for tasks $ \task -> do
+      let mStory = fromTask task
       for mStory $ \story@Story {..} -> do
         let url = "<" <> storyUrl projectId story <> ">"
-        logInfo . display $ url <> " " <> sName
+        logInfo . display $ sName <> " " <> url
 
         let
           incompleteNoCarry =
-            not sCompleted && isNothing sCarryOver && maybe True (> 0) sCost
+            not sCompleted
+              && (isNothing sCarryOver && isNothing sCarryOut)
+              && maybe True (> 0) sCost
+
         when incompleteNoCarry
           $ logWarn
           $ "No carry over on incomplete story: "
@@ -48,68 +53,145 @@ main = do
           (_, _) -> story
 
     let capitalizedStats = statStories $ filter sCapitalized stories
+
     hPutBuilder stdout $ getUtf8Builder $ foldMap
       ("\n" <>)
       [ "Capitalized"
-      , "- " <> display (completed capitalizedStats) <> " / " <> display
-        (commitment capitalizedStats)
+      , "- "
+      <> display (getSum $ completed capitalizedStats)
+      <> " / "
+      <> display (getSum $ commitment capitalizedStats)
       ]
     printStats $ statStories stories
+
+    shouldUpdateCompletedPoints <- promptWith
+      readBool
+      "Update completed points? (y/N)"
+
+    if shouldUpdateCompletedPoints
+      then updateCompletedPoints projectId tasks
+      else logInfo "Skipping completed point update"
+
+updateCompletedPoints :: Gid -> [Task] -> AppM AppExt ()
+updateCompletedPoints projectId tasks =
+  pooledForConcurrentlyN_ maxRequests tasks $ \task -> do
+    let mStory = fromTask task
+    for_ mStory $ \story@(Story {..}) -> do
+      let
+        mCompletedPoints = case (sCompleted, sCarryIn, sCarryOut) of
+          (True, Nothing, _) -> sCost
+          (True, Just carryIn, _) -> Just carryIn
+          (False, _, Just carryOut) -> (-) <$> sCost <*> Just carryOut
+          _ -> Nothing
+
+      case mCompletedPoints of
+        Nothing ->
+          logWarn
+            . display
+            $ "Could not update 'points completed' for story <"
+            <> storyUrl projectId story
+            <> ">"
+        Just completedPoints -> do
+          let mPointsCompletedField = extractPointsCompletedField task
+          case mPointsCompletedField of
+            Nothing ->
+              logWarn
+                . display
+                $ "No 'points completed' field for story "
+                <> storyUrl projectId story
+                <> ">. Skipping."
+            Just pointsCompletedField -> case pointsCompletedField of
+              CustomNumber gid t _ -> do
+                putCustomField
+                  (tGid task)
+                  (CustomNumber gid t (Just $ fromInteger completedPoints))
+                logInfo
+                  . display
+                  $ "Updated 'points completed' for story "
+                  <> display (storyUrl projectId story)
+                  <> " to "
+                  <> display completedPoints
+              _ -> logWarn "'points completed' field has incorrect type."
 
 printStats :: MonadIO m => CompletionStats -> m ()
 printStats stats@CompletionStats {..} =
   hPutBuilder stdout $ getUtf8Builder $ foldMap
     ("\n" <>)
     [ "Completed"
-    , "- new points: " <> display completedNewCost
-    , "- carried over points: " <> display completedCarryOver
-    , "- new stories: " <> display completedNewCount
-    , "- carried over stories: " <> display carriedCount
+    , "- new points: " <> display (getSum completedNewCost)
+    , "- carried over points: " <> display (getSum completedCarryOver)
+    , "- new stories: " <> display (getSum completedNewCount)
+    , "- carried over stories: " <> display (getSum carriedCount)
     , "Incomplete"
-    , "- points completed: " <> display (incompleteCost - incompleteCarryOver)
-    , "- carry over points: " <> display incompleteCarryOver
-    , "- carry over stories: " <> display incompleteCount
+    , "- points completed: "
+      <> display (getSum $ incompleteCost - incompleteCarryOver)
+    , "- carry over points: " <> display (getSum incompleteCarryOver)
+    , "- carry over stories: " <> display (getSum incompleteCount)
     , ""
-    , display (completed stats) <> " / " <> display (commitment stats)
+    , display (getSum $ completed stats) <> " / " <> display
+      (getSum $ commitment stats)
+    , "\n"
     ]
 
-completed :: CompletionStats -> Integer
+completed :: CompletionStats -> Sum Integer
 completed CompletionStats {..} =
   completedNewCost + completedCarryOver + (incompleteCost - incompleteCarryOver)
 
-commitment :: CompletionStats -> Integer
+commitment :: CompletionStats -> Sum Integer
 commitment CompletionStats {..} =
   completedNewCost + completedCarryOver + incompleteCost
 
 statStories :: [Story] -> CompletionStats
-statStories stories = CompletionStats
-  { completedNewCost
-  , completedCarryOver
-  , incompleteCost
-  , incompleteCarryOver
-  , completedNewCount = length completedStories
-  , carriedCount = length carriedStories
-  , incompleteCount = length incompleteStories
+statStories = foldMap storyStats1
+
+storyStats1 :: Story -> CompletionStats
+storyStats1 Story {..} = CompletionStats
+  { completedNewCost = if isNew && sCompleted then cost else mempty
+  , completedCarryOver = if wasCarried && sCompleted then carryIn else mempty
+  , incompleteCost = if not sCompleted then remainingCost else mempty
+  , incompleteCarryOver = carryOut
+  , completedNewCount = if sCompleted && isNew then 1 else mempty
+  , carriedCount = if willCarry then 1 else mempty
+  , incompleteCount = if not sCompleted then 1 else mempty
   }
  where
-  isCarried = isJust . sCarryOver
-  (completedAndCarriedStories, incompleteStories) =
-    partition sCompleted stories
-
-  (carriedStories, completedStories) =
-    partition isCarried completedAndCarriedStories
-  completedNewCost = sum $ mapMaybe sCost completedStories
-  completedCarryOver = sum $ mapMaybe sCarryOver carriedStories
-
-  incompleteCost = sum $ mapMaybe sCost incompleteStories
-  incompleteCarryOver = sum $ mapMaybe sCarryOver incompleteStories
+  isNew = isNothing sCarryIn
+  wasCarried = not isNew
+  willCarry = isJust sCarryOut
+  cost = maybe mempty Sum sCost
+  carryIn = maybe mempty Sum sCarryIn
+  carryOut = maybe mempty Sum sCarryOut
+  remainingCost = maybe mempty Sum $ (-) <$> sCost <*> sCarryOut
 
 data CompletionStats = CompletionStats
-  { completedNewCount :: Int
-  , carriedCount :: Int
-  , incompleteCount :: Int
-  , completedNewCost :: Integer
-  , completedCarryOver :: Integer
-  , incompleteCost :: Integer
-  , incompleteCarryOver :: Integer
-  }
+  { completedNewCount :: Sum Int
+  , carriedCount :: Sum Int
+  , incompleteCount :: Sum Int
+  , completedNewCost :: Sum Integer
+  , completedCarryOver :: Sum Integer
+  , incompleteCost :: Sum Integer
+  , incompleteCarryOver :: Sum Integer
+  } deriving (Generic)
+
+instance Semigroup CompletionStats where
+  (<>) = gmappend
+
+instance Monoid CompletionStats where
+  mempty = gmempty
+
+promptWith :: MonadIO m => (String -> b) -> String -> m b
+promptWith readVar var = liftIO $ do
+  putStr $ var <> ": "
+  hFlush stdout
+  readVar <$> getLine
+
+readBool :: String -> Bool
+readBool str = case map toLower str of
+  'y' : _ -> True
+  _ -> False
+
+extractPointsCompletedField :: Task -> Maybe CustomField
+extractPointsCompletedField Task {..} =
+  headMay $ flip mapMaybe tCustomFields $ \case
+    customField@(CustomNumber _ "points completed" _) -> Just customField
+    _ -> Nothing

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -1,5 +1,3 @@
-
-
 module Main (main) where
 
 import RIO
@@ -146,13 +144,13 @@ statStories = foldMap storyStats1
 
 storyStats1 :: Story -> CompletionStats
 storyStats1 Story {..} = CompletionStats
-  { completedNewCost = if isNew && sCompleted then cost else mempty
-  , completedCarryOver = if wasCarried && sCompleted then carryIn else mempty
-  , incompleteCost = if not sCompleted then remainingCost else mempty
+  { completedNewCost = isNew && sCompleted `implies` cost
+  , completedCarryOver = wasCarried && sCompleted `implies` carryIn
+  , incompleteCost = not sCompleted `implies` remainingCost
   , incompleteCarryOver = carryOut
-  , completedNewCount = if sCompleted && isNew then 1 else mempty
-  , carriedCount = if willCarry then 1 else mempty
-  , incompleteCount = if not sCompleted then 1 else mempty
+  , completedNewCount = sCompleted && isNew `implies` 1
+  , carriedCount = willCarry `implies` 1
+  , incompleteCount = not sCompleted `implies` 1
   }
  where
   isNew = isNothing sCarryIn
@@ -195,3 +193,7 @@ extractPointsCompletedField Task {..} =
   headMay $ flip mapMaybe tCustomFields $ \case
     customField@(CustomNumber _ "points completed" _) -> Just customField
     _ -> Nothing
+
+infixl 1 `implies`
+implies :: Monoid m => Bool -> m -> m
+implies predicate a = if predicate then a else mempty

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -24,6 +24,8 @@ data Story = Story
   , sVirality :: Maybe Integer
   , sImpact :: Maybe Integer
   , sCarryOver :: Maybe Integer
+  , sCarryIn :: Maybe Integer
+  , sCarryOut :: Maybe Integer
   , sCanDo :: Maybe Bool
   , sReproduced :: Maybe Bool
   , sCapitalized :: Bool
@@ -44,6 +46,8 @@ fromTask Task {..} = case tResourceSubtype of
     , sImpact = findInteger "impact" tCustomFields
     , sVirality = findInteger "virality" tCustomFields
     , sCarryOver = findInteger "carryover" tCustomFields
+    , sCarryIn = findInteger "carry in" tCustomFields
+    , sCarryOut = findInteger "carry out" tCustomFields
     , sCanDo = findYesNo "can do?" tCustomFields
     , sReproduced = findYesNo "Reproduces on seed data?" tCustomFields
     , sCapitalized = fromMaybe False $ findYesNo "cap?" tCustomFields

--- a/package.yaml
+++ b/package.yaml
@@ -55,6 +55,8 @@ executables:
     dependencies:
       - asana
       - rio
+      - semigroups
+      - safe
   start-iteration:
     main: Main.hs
     source-dirs: start-iteration

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -52,14 +52,12 @@ main = do
           Just _ -> mayCanDo story
 
     let
-      isCarried Story {..} = isJust sCarryOver || isJust sCarryOut
+      isCarried = isJust . sCarryOver
       (carriedStories, iterationStories) = partition isCarried stories
       iterationCost = sum $ mapMaybe sCost iterationStories
       iterationNum = length iterationStories
-      carriedCost =
-        sum $ mapMaybe (\s -> sCarryOver s <|> sCarryOut s) carriedStories
+      carriedCost = sum $ mapMaybe sCarryOver carriedStories
       carriedNum = length carriedStories
-
     hPutBuilder stdout . getUtf8Builder $ foldMap
       ("\n" <>)
       [ "New Story Points"

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -52,12 +52,14 @@ main = do
           Just _ -> mayCanDo story
 
     let
-      isCarried = isJust . sCarryOver
+      isCarried Story {..} = isJust sCarryOver || isJust sCarryOut
       (carriedStories, iterationStories) = partition isCarried stories
       iterationCost = sum $ mapMaybe sCost iterationStories
       iterationNum = length iterationStories
-      carriedCost = sum $ mapMaybe sCarryOver carriedStories
+      carriedCost =
+        sum $ mapMaybe (\s -> sCarryOver s <|> sCarryOut s) carriedStories
       carriedNum = length carriedStories
+
     hPutBuilder stdout . getUtf8Builder $ foldMap
       ("\n" <>)
       [ "New Story Points"


### PR DESCRIPTION
This commit works with a new version of the Red/Green Iteration template
that has carry in (from previous iteration) and carry out (into next
interation) set as different fields. The calculation for velocity as it
stood was wrong, as it frequently conflated these two concepts.

This commit fixes the calculation of points completed using these two
fields in a backwards-compatible way (for now) and also adds it to a new
field in the project template "points completed" which marks how much of
the cost of each task was completed within the given project. The sum of
'points completed' is the velocity for the iteration.

I plan to add some tooling to start-iteration to swap carry-out to
carry-in and add an 'effective cost' field for each task which marks how
many points are being committed to for the current project for each
task. These stats will give us a much clearer picture of the velocity
for each iteration.