### PR TITLE
Some improvements to start-iteration

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -91,7 +91,8 @@ updateCompletedPoints projectId tasks =
             <> storyUrl projectId story
             <> ">"
         Just completedPoints -> do
-          let mPointsCompletedField = extractPointsCompletedField task
+          let
+            mPointsCompletedField = extractNumberField "points completed" task
           case mPointsCompletedField of
             Nothing ->
               logWarn
@@ -188,12 +189,6 @@ readBool :: String -> Bool
 readBool str = case map toLower str of
   'y' : _ -> True
   _ -> False
-
-extractPointsCompletedField :: Task -> Maybe CustomField
-extractPointsCompletedField Task {..} =
-  headMay $ flip mapMaybe tCustomFields $ \case
-    customField@(CustomNumber _ "points completed" _) -> Just customField
-    _ -> Nothing
 
 infixl 1 `implies`
 implies :: Monoid m => Bool -> m -> m

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -7,12 +7,9 @@ import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
 import Control.Monad (when)
-import Data.Char (toLower)
 import Data.Maybe (isJust, isNothing)
 import Data.Semigroup (Sum(..), (<>))
 import Data.Semigroup.Generic (gmappend, gmempty)
-import Safe (headMay)
-import System.IO (getLine, putStr)
 
 data AppExt = AppExt
   { appProjectId :: Gid
@@ -111,7 +108,7 @@ updateCompletedPoints projectId tasks =
                   <> display (storyUrl projectId story)
                   <> " to "
                   <> display completedPoints
-              _ -> logWarn "'points completed' field has incorrect type."
+              _ -> error "impossible"
 
 printStats :: MonadIO m => CompletionStats -> m ()
 printStats stats@CompletionStats {..} =
@@ -178,17 +175,6 @@ instance Semigroup CompletionStats where
 
 instance Monoid CompletionStats where
   mempty = gmempty
-
-promptWith :: MonadIO m => (String -> b) -> String -> m b
-promptWith readVar var = liftIO $ do
-  putStr $ var <> ": "
-  hFlush stdout
-  readVar <$> getLine
-
-readBool :: String -> Bool
-readBool str = case map toLower str of
-  'y' : _ -> True
-  _ -> False
 
 infixl 1 `implies`
 implies :: Monoid m => Bool -> m -> m

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -51,7 +51,6 @@ import RIO.Time
   , getCurrentTime
   , iso8601DateFormat
   )
-import Safe (headMay)
 
 -- | Just what we need out of our @custom_fields@ for cost and carry-over
 data CustomField
@@ -190,14 +189,13 @@ taskUrl Task {..} = "https://app.asana.com/0/0/" <> gidToText tGid <> "/f"
 
 extractNumberField :: Text -> Task -> Maybe CustomField
 extractNumberField fieldName Task {..} =
-  headMay $ flip mapMaybe tCustomFields $ \case
-    customField@(CustomNumber _ t _) ->
-      if t == fieldName then Just customField else Nothing
+  listToMaybe $ flip mapMaybe tCustomFields $ \case
+    customField@(CustomNumber _ t _) -> customField <$ guard (t == fieldName)
     _ -> Nothing
 
 extractEnumField :: Text -> Task -> Maybe CustomField
 extractEnumField fieldName Task {..} =
-  headMay $ flip mapMaybe tCustomFields $ \case
+  listToMaybe $ flip mapMaybe tCustomFields $ \case
     customField@(CustomEnum _ t _ _) ->
       if t == fieldName then Just customField else Nothing
     _ -> Nothing

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -12,6 +12,8 @@ module Asana.Api.Task
   , putCustomField
   , putCustomFields
   , taskUrl
+  , extractNumberField
+  , extractEnumField
   ) where
 
 import RIO
@@ -49,6 +51,7 @@ import RIO.Time
   , getCurrentTime
   , iso8601DateFormat
   )
+import Safe (headMay)
 
 -- | Just what we need out of our @custom_fields@ for cost and carry-over
 data CustomField
@@ -184,3 +187,17 @@ putCustomFields taskId fields = put ("/tasks/" <> T.unpack (gidToText taskId))
 
 taskUrl :: Task -> Text
 taskUrl Task {..} = "https://app.asana.com/0/0/" <> gidToText tGid <> "/f"
+
+extractNumberField :: Text -> Task -> Maybe CustomField
+extractNumberField fieldName Task {..} =
+  headMay $ flip mapMaybe tCustomFields $ \case
+    customField@(CustomNumber _ t _) ->
+      if t == fieldName then Just customField else Nothing
+    _ -> Nothing
+
+extractEnumField :: Text -> Task -> Maybe CustomField
+extractEnumField fieldName Task {..} =
+  headMay $ flip mapMaybe tCustomFields $ \case
+    customField@(CustomEnum _ t _ _) ->
+      if t == fieldName then Just customField else Nothing
+    _ -> Nothing

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -18,12 +18,16 @@ module Asana.App
   , parseBugProjectId
   , parseYear
   , parseImport
+  -- * Prompts
+  , promptWith
+  , readBool
   ) where
 
 import RIO
 
 import Asana.Api.Gid (Gid, textToGid)
 import Control.Monad.IO.Class (liftIO)
+import Data.Char (toLower)
 import Data.Semigroup ((<>))
 import LoadEnv (loadEnvFrom)
 import Options.Applicative
@@ -43,7 +47,7 @@ import Options.Applicative
 import RIO.Text (Text)
 import qualified RIO.Text as T
 import System.Environment (getEnv)
-import System.IO (stderr)
+import System.IO (getLine, putStr, stderr)
 
 data AppWith ext = App
   { appApiAccessKey :: Text
@@ -113,3 +117,14 @@ parseYear = option auto (long "year" <> help "The year to view")
 
 parseImport :: Parser (Maybe FilePath)
 parseImport = optional (strOption (long "import" <> help "CSV File to import"))
+
+promptWith :: MonadIO m => (String -> b) -> String -> m b
+promptWith readVar var = liftIO $ do
+  putStr $ var <> ": "
+  hFlush stdout
+  readVar <$> getLine
+
+readBool :: String -> Bool
+readBool str = case map toLower str of
+  'y' : _ -> True
+  _ -> False

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -21,6 +21,7 @@ data Story = Story
   , sCompleted :: Bool
   , sCompletedAt :: Maybe UTCTime
   , sCost :: Maybe Integer
+  , sCommitment :: Maybe Integer
   , sVirality :: Maybe Integer
   , sImpact :: Maybe Integer
   , sCarryOver :: Maybe Integer
@@ -43,6 +44,7 @@ fromTask Task {..} = case tResourceSubtype of
     , sCompleted = tCompleted || awaitingDeployment
     , sCompletedAt = tCompletedAt
     , sCost = findInteger "cost" tCustomFields
+    , sCommitment = findInteger "commitment" tCustomFields
     , sImpact = findInteger "impact" tCustomFields
     , sVirality = findInteger "virality" tCustomFields
     , sCarryOver = findInteger "carryover" tCustomFields

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,6 @@ library:
     - optparse-applicative
     - rio
     - scientific
-    - safe
 
 executables:
   bug-reproduction:

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ library:
     - optparse-applicative
     - rio
     - scientific
+    - safe
 
 executables:
   bug-reproduction:
@@ -97,4 +98,3 @@ executables:
       - rio
       - text
       - cassava
-      - safe

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,6 @@ executables:
       - asana
       - rio
       - semigroups
-      - safe
   start-iteration:
     main: Main.hs
     source-dirs: start-iteration

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -22,14 +22,30 @@ main = do
   app <- loadAppWith $ AppExt <$> parseProjectId <*> parseIgnoreNoCanDo
   runApp app $ do
     projectId <- asks $ appProjectId . appExt
-    tasks <- getProjectTasks projectId AllTasks
+    projectTasks <- getProjectTasks projectId AllTasks
 
-    let
-      processStories =
-        fmap catMaybes . pooledForConcurrentlyN maxRequests tasks
+    tasks <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
 
-    stories <- processStories $ \Named {..} -> runMaybeT $ do
-      story@Story {..} <- MaybeT $ fromTask <$> getTask nGid
+    shouldUpdateCommitment <- promptWith readBool "Update commitment? (y/N)"
+    shouldMoveCarryOut <- promptWith
+      readBool
+      "Move carry out to carry in? (y/N)"
+
+    if shouldUpdateCommitment
+      then pooledForConcurrentlyN_
+        maxRequests
+        tasks
+        (updateCommitment projectId)
+      else logInfo "Skipping commitment update"
+
+    if shouldMoveCarryOut
+      then pooledForConcurrentlyN_ maxRequests tasks (moveCarryOutIn projectId)
+      else logInfo "Skipping carry out -> carry in move"
+
+    -- Re-fetch tasks after making changes to commitment/carry in
+    tasks1 <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
+    stories <- fmap catMaybes . for tasks1 $ \task -> runMaybeT $ do
+      story@Story {..} <- MaybeT $ pure $ fromTask task
       let url = "<" <> storyUrl projectId story <> ">"
       MaybeT $ do
         logInfo . display $ url <> " " <> sName
@@ -45,6 +61,14 @@ main = do
           . logWarn
           $ "Story is not costed: "
           <> display url
+        when (isJust sCarryOut)
+          . logWarn
+          $ "Story still has 'carry out' (did you mean to move to 'carry in'?): "
+          <> display url
+        when (isNothing sCommitment)
+          . logWarn
+          $ "Story has no 'commitment' (did you mean to update it?): "
+          <> display url
         case sAssignee of
           Nothing -> do
             logWarn $ "Story has no assignee: " <> display url
@@ -52,12 +76,13 @@ main = do
           Just _ -> mayCanDo story
 
     let
-      isCarried = isJust . sCarryOver
+      isCarried = isJust . sCarryIn
       (carriedStories, iterationStories) = partition isCarried stories
       iterationCost = sum $ mapMaybe sCost iterationStories
       iterationNum = length iterationStories
-      carriedCost = sum $ mapMaybe sCarryOver carriedStories
+      carriedCost = sum $ mapMaybe sCarryIn carriedStories
       carriedNum = length carriedStories
+
     hPutBuilder stdout . getUtf8Builder $ foldMap
       ("\n" <>)
       [ "New Story Points"
@@ -76,6 +101,78 @@ main = do
       <> " stories)"
       ]
 
+-- | Calculate commitment for this iteration and update the @commitment@ field
+updateCommitment :: Gid -> Task -> AppM AppExt ()
+updateCommitment projectId task = do
+  let mStory = fromTask task
+  for_ mStory $ \story@Story {..} -> do
+    let
+      mCommitment = case sCarryIn of
+        Nothing -> sCost
+        Just carryIn -> Just carryIn
+      mCommitmentField = extractNumberField "commitment" task
+
+    case mCommitmentField of
+      Nothing ->
+        logWarn
+          . display
+          $ "No 'commitment' field for story "
+          <> storyUrl projectId story
+          <> ">. Skipping."
+      Just commitmentField -> case commitmentField of
+        CustomNumber gid t _ -> do
+          putCustomField
+            (tGid task)
+            (CustomNumber gid t (fromInteger <$> mCommitment))
+          logInfo
+            . display
+            $ "Updated 'commitment' for story "
+            <> display (storyUrl projectId story)
+            <> " to "
+            <> displayShow mCommitment
+        _ -> error "impossible"
+
+-- | Move @carry out@ to @carry in@ if it is set.
+moveCarryOutIn :: Gid -> Task -> AppM AppExt ()
+moveCarryOutIn projectId task = do
+  let mStory = fromTask task
+  for_ mStory $ \story@Story {..} -> case sCarryOut of
+    Nothing ->
+      logInfo
+        . display
+        $ "No 'carry out' for story "
+        <> makeUrl projectId story
+        <> ". Skipping copy."
+    Just carryOut -> do
+      let mCarryInField = extractNumberField "carry in" task
+      let mCarryOutField = extractNumberField "carry in" task
+
+      case mCarryInField of
+        Nothing ->
+          logWarn
+            . display
+            $ "No 'carry in' field for story "
+            <> makeUrl projectId story
+            <> ". Skipping copy."
+        Just (CustomNumber gid t _) -> do
+          putCustomField
+            (tGid task)
+            (CustomNumber gid t (Just $ fromInteger carryOut))
+
+          -- Wipe @carry out@
+          case mCarryOutField of
+            Just (CustomNumber outGid outT _) ->
+              putCustomField (tGid task) (CustomNumber outGid outT Nothing)
+            _ -> error "impossible"
+
+          logInfo
+            . display
+            $ "Updated 'carry in' for story "
+            <> makeUrl projectId story
+            <> " to "
+            <> tshow carryOut
+        Just _ -> error "impossible"
+
 makeUrl :: Gid -> Story -> Text
 makeUrl projectId story = "<" <> storyUrl projectId story <> ">"
 
@@ -85,7 +182,7 @@ mayCanDo story = do
   let url = makeUrl projectId story
   case sCanDo story of
     Nothing -> do
-      logWarn $ "Story does not have a \"can do?\": " <> display url
+      logWarn $ "Story does not have a 'can do?': " <> display url
       ignoreNoCanDo <- asks $ appIgnoreNoCanDo . appExt
       pure $ if ignoreNoCanDo then Nothing else Just story
     Just canDo -> do

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -107,9 +107,7 @@ updateCommitment projectId task = do
   let mStory = fromTask task
   for_ mStory $ \story@Story {..} -> do
     let
-      mCommitment = case sCarryIn of
-        Nothing -> sCost
-        Just carryIn -> Just carryIn
+      mCommitment = sCarryIn <|> sCost
       mCommitmentField = extractNumberField "commitment" task
 
     case mCommitmentField of


### PR DESCRIPTION
This updates the `start-iteration` workflow with the new structure of
the R/G asana templates, which includes:

1. `carry in`
2. `carry out`
3. `commitment`

This also adds a couple of new warnings as well as the ability to swap
'carry out' for 'carry in', which is necessary at the beginning of the
database. It also allows adding `commitment` values so we can easily
track the target velocity of each iteration.