### PR TITLE
Sort planning-poker tasks by base project order

### DIFF
--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -22,7 +22,7 @@ main = do
   runApp app $ do
     projectId <- asks $ appProjectId . appExt
     perspective <- asks $ appPerspective . appExt
-    projectTasks <- getProjectTasks projectId AllTasks
+    projectTasks <- getProjectTasks projectId mempty
 
     tasks <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
 

--- a/cycle-time/Main.hs
+++ b/cycle-time/Main.hs
@@ -136,8 +136,8 @@ fetchRelevantTaskGids projects = do
     $ \project -> do
         logDebug . fromString $ "Project tasks: " <> show
           (gidToText $ pGid project)
-        fmap nGid <$> getProjectTasks (pGid project) AllTasks
+        fmap nGid <$> getProjectTasks (pGid project) mempty
   bugProjectGid <- asks $ appBugProject . appExt
-  bugTaskGids <- fmap nGid <$> getProjectTasks bugProjectGid AllTasks
+  bugTaskGids <- fmap nGid <$> getProjectTasks bugProjectGid mempty
 
   pure $ filter (`notElem` bugTaskGids) taskGids

--- a/debt-evaluation/Main.hs
+++ b/debt-evaluation/Main.hs
@@ -30,6 +30,7 @@ import Asana.Story
 import Control.Monad (guard, when)
 import Data.Foldable (maximum, minimum)
 import Data.Maybe (mapMaybe)
+import Data.Semigroup (Last(..))
 import RIO.Text (Text)
 import Text.Printf (printf)
 
@@ -72,7 +73,7 @@ main = do
     logDebug "Fetch stories"
     tasks <- getProjectTasks
       projectId
-      mempty { taskStatusFilter = IncompletedTasks }
+      mempty { taskStatusFilter = Last IncompletedTasks }
     let
       processStories =
         fmap catMaybes . pooledForConcurrentlyN maxRequests tasks

--- a/debt-evaluation/Main.hs
+++ b/debt-evaluation/Main.hs
@@ -70,7 +70,9 @@ main = do
     projectId <- asks $ appProjectId . appExt
 
     logDebug "Fetch stories"
-    tasks <- getProjectTasks projectId IncompletedTasks
+    tasks <- getProjectTasks
+      projectId
+      mempty { taskStatusFilter = IncompletedTasks }
     let
       processStories =
         fmap catMaybes . pooledForConcurrentlyN maxRequests tasks

--- a/library/Asana/Api/Generic.hs
+++ b/library/Asana/Api/Generic.hs
@@ -1,0 +1,11 @@
+module Asana.Api.Generic (GenericAsanaTask) where
+
+import Data.Aeson (FromJSON)
+
+-- Class of things that can be parsed as "tasks"
+--
+-- Since Asana's API is extensible, it makes sense to allow the user some
+-- ability to change the way a @Task@ is parsed. This gives us a little bit of
+-- flexibility when it comes to the myriad ways a @Task@ list can be fetched
+-- (see @getProjectTasks@)
+class FromJSON a => GenericAsanaTask a

--- a/library/Asana/Api/Named.hs
+++ b/library/Asana/Api/Named.hs
@@ -5,6 +5,7 @@ module Asana.Api.Named
 
 import RIO
 
+import Asana.Api.Generic (GenericAsanaTask)
 import Asana.Api.Gid (Gid)
 import Data.Aeson (FromJSON, genericParseJSON, parseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
@@ -18,3 +19,5 @@ data Named = Named
 
 instance FromJSON Named where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
+
+instance GenericAsanaTask Named

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -156,9 +156,8 @@ getTask taskId = getSingle $ "/tasks/" <> T.unpack (gidToText taskId)
 data TaskStatusFilter = IncompletedTasks | AllTasks
   deriving (Show, Eq)
 
-data OptField = OptField
-  { optFieldKey :: Text
-  , optFieldValue :: Text
+newtype OptField = OptField
+  { getOptField :: Text
   }
   deriving (Show, Eq)
 
@@ -185,11 +184,18 @@ getProjectTasks projectId TaskSchema {..} = do
   now <- liftIO getCurrentTime
   getAllParams
     (T.unpack $ "/projects/" <> gidToText projectId <> "/tasks")
-    (completedSince now)
+    (completedSince now <> optFields)
  where
   completedSince now = case taskStatusFilter of
     AllTasks -> []
     IncompletedTasks -> [("completed_since", formatISO8601 now)]
+  optFields = case taskOptFields of
+    [] -> []
+    _ ->
+      [ ( "opt_fields"
+        , T.unpack $ T.intercalate "," (map getOptField taskOptFields)
+        )
+      ]
 
 formatISO8601 :: FormatTime t => t -> String
 formatISO8601 = formatTime defaultTimeLocale (iso8601DateFormat Nothing)

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -16,6 +16,7 @@ module Asana.App
   , parsePessimistic
   , parseProjectId
   , parseBugProjectId
+  , parseTeamProjectId
   , parseYear
   , parseImport
   -- * Prompts
@@ -107,6 +108,10 @@ parsePessimistic = flag Optimistic Pessimistic (long "pessimistic")
 parseProjectId :: Parser Gid
 parseProjectId =
   textToGid . T.pack <$> strOption (long "project" <> help "Project Id")
+
+parseTeamProjectId :: Parser Gid
+parseTeamProjectId =
+  textToGid . T.pack <$> strOption (long "team-project" <> help "Team-specific Project Id")
 
 parseBugProjectId :: Parser Gid
 parseBugProjectId =

--- a/package.yaml
+++ b/package.yaml
@@ -92,6 +92,8 @@ executables:
     main: Main.hs
     source-dirs: planning-poker
     dependencies:
+      - aeson
+      - aeson-casing
       - asana
       - rio
       - text

--- a/planning-poker/Main.hs
+++ b/planning-poker/Main.hs
@@ -28,7 +28,7 @@ main = do
 
 exportProjectTasks :: Gid -> AppM AppExt ()
 exportProjectTasks projectId = do
-  projectTasks <- getProjectTasks projectId AllTasks
+  projectTasks <- getProjectTasks projectId mempty
 
   tasks <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
 
@@ -49,7 +49,7 @@ importProjectTasksFromFile file projectId = do
   case decodeByName contents of
     Left err -> logError $ fromString err
     Right (_, tasks) -> do
-      projectTaskGids <- map nGid <$> getProjectTasks projectId AllTasks
+      projectTaskGids <- map nGid <$> getProjectTasks projectId mempty
       projectTasks <- pooledForConcurrentlyN maxRequests projectTaskGids getTask
       let projectTaskMap = HashMap.fromList $ map (tGid &&& id) projectTasks
 

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -22,7 +22,7 @@ main = do
   app <- loadAppWith $ AppExt <$> parseProjectId <*> parseIgnoreNoCanDo
   runApp app $ do
     projectId <- asks $ appProjectId . appExt
-    projectTasks <- getProjectTasks projectId AllTasks
+    projectTasks <- getProjectTasks projectId mempty
 
     tasks <- pooledForConcurrentlyN maxRequests projectTasks (getTask . nGid)
 


### PR DESCRIPTION
I recommend reviewing this one by individual commits:

- 9aa200a makes use of the fact that Asana's API responses are extensible; that is, you can request which fields to return. The commit message has more context. We need this in order to fetch a task's projects.
- 24a136b utilizes this change to fetch and sort planning-poker tasks by base project order.