### PR TITLE
Add the ability to create and search for tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 *.log
 *.hoo
 **/client_session_key.aes
-*.cabal
 *.prof

--- a/asana.cabal
+++ b/asana.cabal
@@ -1,0 +1,140 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 9bce87dc1d3abe7323f340eb95ba2782b564f6a4dcbac42d49ca2a47e1f257be
+
+name:           asana
+version:        0.0.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Asana.Api
+      Asana.Api.Gid
+      Asana.Api.Named
+      Asana.Api.Project
+      Asana.Api.Request
+      Asana.Api.Task
+      Asana.App
+      Asana.Story
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      library
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      aeson
+    , aeson-casing
+    , base
+    , http-conduit
+    , load-env
+    , optparse-applicative
+    , rio
+    , scientific
+  default-language: Haskell2010
+
+executable bug-reproduction
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      bug-reproduction
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , rio
+    , semigroups
+  default-language: Haskell2010
+
+executable close-iteration
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      close-iteration
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , rio
+    , semigroups
+  default-language: Haskell2010
+
+executable cycle-time
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      cycle-time
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , cassava
+    , containers
+    , rio
+    , statistics
+    , temporary
+    , vector
+  default-language: Haskell2010
+
+executable debt-evaluation
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      debt-evaluation
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , rio
+  default-language: Haskell2010
+
+executable planning-poker
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      planning-poker
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , cassava
+    , rio
+    , text
+  default-language: Haskell2010
+
+executable start-iteration
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      start-iteration
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , rio
+    , transformers
+  default-language: Haskell2010
+
+executable update-task
+  main-is: Main.hs
+  other-modules:
+      Paths_asana
+  hs-source-dirs:
+      update-task
+  default-extensions: BangPatterns DataKinds DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
+  build-depends:
+      asana
+    , base
+    , optparse-applicative
+    , rio
+    , text
+  default-language: Haskell2010

--- a/library/Asana/Api/Gid.hs
+++ b/library/Asana/Api/Gid.hs
@@ -7,12 +7,12 @@ module Asana.Api.Gid
 
 import RIO
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import RIO.Text (Text)
 
 newtype Gid = Gid { gidToText :: Text }
   deriving (Eq, Generic, Show)
-  deriving newtype (FromJSON, ToJSON, Hashable)
+  deriving newtype (FromJSON, ToJSON, ToJSONKey, FromJSONKey, Hashable)
 
 textToGid :: Text -> Gid
 textToGid = Gid

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -62,7 +62,7 @@ instance ToJSON a => ToJSON (ApiData a) where
 data CustomField
   = CustomNumber Gid Text (Maybe Scientific)
   | CustomEnum Gid Text [EnumOption] (Maybe Text)
-  | CustomText Gid (Maybe Text)
+  | CustomText Gid Text (Maybe Text)
   | Other -- ^ Unexpected types dumped here
   deriving (Eq, Generic, Show)
 
@@ -105,7 +105,7 @@ instance FromJSON CustomField where
     oType <- o .: "type"
 
     case (oType :: Text) of
-      "text" -> CustomText <$> o .: "gid" <*> o .: "text_value"
+      "text" -> CustomText <$> o .: "gid" <*> o .: "name" <*> o .: "text_value"
       "number" ->
         CustomNumber <$> o .: "gid" <*> o .: "name" <*> o .: "number_value"
       "enum" -> do

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -176,8 +176,8 @@ instance ToJSON PostTask where
   toEncoding = genericToEncoding $ aesonPrefix snakeCase
 
 -- | Create a new 'Task'
-postTask :: PostTask -> AppM ext (Result (ApiData Task))
-postTask body = fromJSON <$> post "/tasks" (ApiData body)
+postTask :: PostTask -> AppM ext (Result Task)
+postTask body = fmap adData . fromJSON <$> post "/tasks" (ApiData body)
 
 data TaskTypeFilter = TasksOnly | SubtasksOnly | AllTaskTypes
 

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -7,7 +7,6 @@ module Asana.Api.Task
   , TaskStatusFilter(..)
   , TaskTypeFilter(..)
   , ResourceSubtype(..)
-  , ProjectId(..)
   , PostTask(..)
   , SearchWorkspace(..)
   , getTask
@@ -160,11 +159,8 @@ instance FromJSON Task where
 getTask :: Gid -> AppM ext Task
 getTask taskId = getSingle $ "/tasks/" <> T.unpack (gidToText taskId)
 
-newtype ProjectId = ProjectId { getProjectId :: Text }
-  deriving newtype (ToJSON, FromJSON)
-
-data PostTask= PostTask
-  { ptProjects :: [ProjectId]
+data PostTask = PostTask
+  { ptProjects :: [Gid]
   , ptCustomFields :: HashMap Gid Text
   , ptName :: Text
   , ptNotes :: Text

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -61,18 +61,18 @@ fromTask Task {..} = case tResourceSubtype of
       Just Named {..} | caseFoldEq nName "Awaiting Deployment" -> True
       _ -> False
 
-findInteger :: Text -> [CustomField] -> Maybe Integer
+findInteger :: Text -> CustomFields -> Maybe Integer
 findInteger field = fmap round . findNumber field
 
-findNumber :: Text -> [CustomField] -> Maybe Scientific
-findNumber field = listToMaybe . mapMaybe cost
+findNumber :: Text -> CustomFields -> Maybe Scientific
+findNumber field = listToMaybe . mapMaybe cost . getCustomFields
  where
   cost = \case
     (CustomNumber _ foundField mn) | caseFoldEq field foundField -> mn
     _ -> Nothing
 
-findYesNo :: Text -> [CustomField] -> Maybe Bool
-findYesNo x = fmap parse . listToMaybe . mapMaybe go
+findYesNo :: Text -> CustomFields -> Maybe Bool
+findYesNo x = fmap parse . listToMaybe . mapMaybe go . getCustomFields
  where
   go (CustomEnum _ name _ mn) | caseFoldEq name x = mn
   go _ = Nothing

--- a/update-task/Main.hs
+++ b/update-task/Main.hs
@@ -43,9 +43,9 @@ readSet = go . pack
     (k, v) | not (T.null v) -> Right $ Set (Custom k) $ T.drop 1 v
     _ -> Left "Invalid filter, must be <field>:[value]"
 
-override :: [CustomField] -> Set -> Maybe CustomField
+override :: CustomFields -> Set -> Maybe CustomField
 override fields (Set (Custom name) val) = do
-  field <- find (named name) fields
+  field <- find (named name) (getCustomFields fields)
 
   case field of
     CustomNumber gid _ _ -> do

--- a/update-task/Main.hs
+++ b/update-task/Main.hs
@@ -52,10 +52,12 @@ override fields (Set (Custom name) val) = do
       n <- readMaybe $ unpack val
       Just $ CustomNumber gid name $ Just n
     CustomEnum gid _ opts _ -> Just $ CustomEnum gid name opts $ Just val
+    CustomText gid _ -> Just $ CustomText gid (Just val)
     Other -> Nothing
 
 named :: Text -> CustomField -> Bool
 named name = \case
   CustomNumber _ n _ -> name == n
   CustomEnum _ n _ _ -> name == n
+  CustomText _ n -> name == n
   Other -> False

--- a/update-task/Main.hs
+++ b/update-task/Main.hs
@@ -52,12 +52,12 @@ override fields (Set (Custom name) val) = do
       n <- readMaybe $ unpack val
       Just $ CustomNumber gid name $ Just n
     CustomEnum gid _ opts _ -> Just $ CustomEnum gid name opts $ Just val
-    CustomText gid _ -> Just $ CustomText gid (Just val)
+    CustomText gid _ _ -> Just $ CustomText gid name $ Just val
     Other -> Nothing
 
 named :: Text -> CustomField -> Bool
 named name = \case
   CustomNumber _ n _ -> name == n
   CustomEnum _ n _ _ -> name == n
-  CustomText _ n -> name == n
+  CustomText _ n _ -> name == n
   Other -> False


### PR DESCRIPTION
Adds two new bits and pieces to the library:

1. The ability to POST `Task`s to Asana, which creates them.
2. The ability to search for tasks within a workspace (paid feature).

A little bit of refactoring slipped in as I needed to parse out `data`-enveloped API responses, which were re-usable in some of our request bodies. Additionally, we can now parse out text-based custom fields, which was helpful while I was debugging this stuff.