### PR TITLE
Modify asana stat calculators to work on top-level iterations and filter to team-specific ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.hoo
 **/client_session_key.aes
 *.prof
+**/*.dump-hi
+**/*.hie
+*.csv

--- a/asana.cabal
+++ b/asana.cabal
@@ -4,10 +4,12 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9bce87dc1d3abe7323f340eb95ba2782b564f6a4dcbac42d49ca2a47e1f257be
+-- hash: 65b9f3ae2739b428e42a39a65acbd1c848d028eb46731b3eec5d82c590605318
 
 name:           asana
 version:        0.0.0
+license:        MIT
+license-file:   LICENSE
 build-type:     Simple
 
 library
@@ -60,6 +62,7 @@ executable close-iteration
   build-depends:
       asana
     , base
+    , optparse-applicative
     , rio
     , semigroups
   default-language: Haskell2010

--- a/asana.cabal
+++ b/asana.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 65b9f3ae2739b428e42a39a65acbd1c848d028eb46731b3eec5d82c590605318
+-- hash: 3786d76638a780fb2699d3182b771b7c630d5ae3246105b888448df3e9d8739d
 
 name:           asana
 version:        0.0.0
@@ -62,7 +62,6 @@ executable close-iteration
   build-depends:
       asana
     , base
-    , optparse-applicative
     , rio
     , semigroups
   default-language: Haskell2010

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -11,7 +11,6 @@ import Control.Monad (when)
 import Data.Maybe (isJust, isNothing)
 import Data.Semigroup (Sum(..), (<>))
 import Data.Semigroup.Generic (gmappend, gmempty)
-import Options.Applicative
 import qualified RIO.Text as T
 
 data AppExt = AppExt
@@ -21,8 +20,7 @@ data AppExt = AppExt
 
 main :: IO ()
 main = do
-  app <- loadAppWith $ AppExt <$> parseProjectId <*> optional
-    (strOption (long "subproject" <> help "Optional subproject name"))
+  app <- loadAppWith $ AppExt <$> parseProjectId <*> parseSubprojectName
 
   runApp app $ do
     projectId <- asks $ appProjectId . appExt

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -121,7 +121,6 @@ instance FromJSON CustomField where
                 _ -> pure Nothing
       _ -> pure Other
 
--- | We need to know Section to find "Awaiting Deployment"
 data Membership = Membership
   { mProject :: Named
   , mSection :: Maybe Named

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -18,6 +18,7 @@ module Asana.App
   , parseBugProjectId
   , parseYear
   , parseImport
+  , parseSubprojectName
   -- * Prompts
   , promptWith
   , readBool
@@ -117,6 +118,10 @@ parseYear = option auto (long "year" <> help "The year to view")
 
 parseImport :: Parser (Maybe FilePath)
 parseImport = optional (strOption (long "import" <> help "CSV File to import"))
+
+parseSubprojectName :: Parser (Maybe String)
+parseSubprojectName =
+  optional (strOption (long "subproject" <> help "Optional subproject name"))
 
 promptWith :: MonadIO m => (String -> b) -> String -> m b
 promptWith readVar var = liftIO $ do

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -43,8 +43,8 @@ fromTask Task {..} = case tResourceSubtype of
     , sName = tName
     , sCompleted = tCompleted || awaitingDeployment
     , sCompletedAt = tCompletedAt
-    , sCost = findInteger "cost" tCustomFields
-    , sCommitment = findInteger "commitment" tCustomFields
+    , sCost
+    , sCommitment = sCarryIn <|> sCost
     , sImpact = findInteger "impact" tCustomFields
     , sVirality = findInteger "virality" tCustomFields
     , sCanDo = findYesNo "can do?" tCustomFields
@@ -59,7 +59,7 @@ fromTask Task {..} = case tResourceSubtype of
     case mSection of
       Just Named {..} | caseFoldEq nName "Awaiting Deployment" -> True
       _ -> False
-
+  sCost = findInteger "cost" tCustomFields
   isCarryIn = flip any tMemberships $ \Membership {..} -> case mSection of
     Just Named {..} | "carryover" `T.isInfixOf` T.toLower nName -> True
     _ -> False

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -61,7 +61,7 @@ fromTask Task {..} = case tResourceSubtype of
       _ -> False
 
   isCarryIn = flip any tMemberships $ \Membership {..} -> case mSection of
-    Just Named {..} | caseFoldEq nName "(101) Carryover" -> True
+    Just Named {..} | "carryover" `T.isInfixOf` T.toLower nName -> True
     _ -> False
 
   sCarryIn = do

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,6 @@ executables:
       - asana
       - rio
       - semigroups
-      - optparse-applicative
   start-iteration:
     main: Main.hs
     source-dirs: start-iteration

--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ executables:
       - asana
       - rio
       - semigroups
+      - optparse-applicative
   start-iteration:
     main: Main.hs
     source-dirs: start-iteration


### PR DESCRIPTION
By commit:

a01ef5f

This commit changes `close-iteration` to work only on the carryover
field in asana, but splits that carryover depending on the specific
_section_ it is in. In order to accomplish this, we now operate on the
top-level project (e.g. Iteration 152) with project id and supply the
name of the subproject to filter to for stat gathering.

For example,

```
stack exec -- close-iteration --project <project id> --subproject R152
```

Will provide stats for R152, provided that `<project id>` is for
Iteration 152.

For curriculum iterations , subproject need not be supplied, so it is
left as an optional argument.

e8253a1

This does the same thing as the previous commit, but for
`start-iteration`: We now operate on the top-level project and filter
down to subprojects to calculate stats.