### PR TITLE
Properly filter down to only current-iteration's carryover section

### DIFF
--- a/bug-reproduction/Main.hs
+++ b/bug-reproduction/Main.hs
@@ -46,7 +46,7 @@ main = do
     let
       accumulateStory :: Totals -> Named -> AppM ext Totals
       accumulateStory totals named = do
-        mStory <- fromTask <$> getTask (nGid named)
+        mStory <- fromTask Nothing <$> getTask (nGid named)
         case mStory of
           Nothing -> pure mempty
           Just story@Story {..} -> do

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -40,7 +40,7 @@ main = do
               T.toLower (nName mProject) == T.toLower (T.pack subprojectName)
 
     stories <- fmap catMaybes . for tasks $ \task -> do
-      let mStory = fromTask task
+      let mStory = fromTask (Just projectId) task
       for mStory $ \story@Story {..} -> do
         let
           url = "<" <> storyUrl projectId story <> ">"
@@ -97,7 +97,7 @@ getCompletedPoints Story {..} = case (sCompleted, sCarryIn, sCarryOut) of
 updateCompletedPoints :: Gid -> [Task] -> AppM AppExt ()
 updateCompletedPoints projectId tasks =
   pooledForConcurrentlyN_ maxRequests tasks $ \task -> do
-    let mStory = fromTask task
+    let mStory = fromTask (Just projectId) task
     for_ mStory $ \story@Story {..} -> case getCompletedPoints story of
       Nothing ->
         logWarn

--- a/debt-evaluation/Main.hs
+++ b/debt-evaluation/Main.hs
@@ -75,7 +75,7 @@ main = do
       processStories =
         fmap catMaybes . pooledForConcurrentlyN maxRequests tasks
     stories <- processStories $ \Named {..} -> do
-      mStory <- fromTask <$> getTask nGid
+      mStory <- fromTask Nothing <$> getTask nGid
       for mStory $ \story -> do
         let url = "<" <> storyUrl projectId story <> ">"
         logInfo . display $ url <> " " <> sName story

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -46,7 +46,7 @@ main = do
               T.toLower (nName mProject) == T.toLower (T.pack subprojectName)
 
     stories <- fmap catMaybes . for tasks $ \task -> runMaybeT $ do
-      story@Story {..} <- MaybeT $ pure $ fromTask task
+      story@Story {..} <- MaybeT $ pure $ fromTask (Just projectId) task
       let url = "<" <> storyUrl projectId story <> ">"
       MaybeT $ do
         logInfo . display $ url <> " " <> sName


### PR DESCRIPTION
If carryover has already been added to the carryover section for the
next iteration, it will currently be considered as carry-in for the
current iteration. This commit allows filtering down to the exact
carryover section within the current iteration to determine carryover to
avoid that issue. Now it doesn't matter when carryover is added to the
next iteration - if it is not carry for the current iteration, it will
not be considered carry-in.