### PR TITLE
Move library functions away from AppWith type

### DIFF
--- a/library/Asana/Api/Project.hs
+++ b/library/Asana/Api/Project.hs
@@ -6,8 +6,7 @@ module Asana.Api.Project
 import RIO
 
 import Asana.Api.Gid (Gid)
-import Asana.Api.Request (getAllParams)
-import Asana.App (AppM)
+import Asana.Api.Request (HasAsana, getAllParams)
 import Data.Aeson (FromJSON, genericParseJSON, parseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
 import RIO.Text (Text)
@@ -24,7 +23,9 @@ data Project = Project
 instance FromJSON Project where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
 
-getProjects :: AppM ext [Project]
+getProjects
+  :: (MonadUnliftIO m, MonadReader env m, HasLogFunc env, HasAsana env)
+  => m [Project]
 getProjects = getAllParams
   (T.unpack "/projects/")
   [("team", "12760955045995"), ("opt_fields", "created_at,name")]

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -27,6 +27,7 @@ module Asana.App
 import RIO
 
 import Asana.Api.Gid (Gid, textToGid)
+import Asana.Api.Request (HasAsana(..))
 import Control.Monad.IO.Class (liftIO)
 import Data.Char (toLower)
 import Data.Semigroup ((<>))
@@ -61,6 +62,10 @@ type App = AppWith ()
 
 instance HasLogFunc (AppWith ext) where
   logFuncL = lens logFunc (\app logFunc -> app { logFunc })
+
+instance HasAsana (AppWith ext) where
+  asanaApiAccessKeyL =
+    lens appApiAccessKey $ \app appApiAccessKey -> app { appApiAccessKey }
 
 data Perspective = Pessimistic | Optimistic
 


### PR DESCRIPTION
Rather than relying on a concrete App type, we can use a Has class to look for
the API key. This means we can re-use these library functions in other
applications with their own concrete App types.

This pattern is how almost all RIO-aware functions are written. You can tell
we're following things correctly when the only imports of our App module are in
the executables.

One choice I made was to go with the pure `parseRequest_` instead of keeping
`postRequest`. The latter would've required `MonadThrow` in all the constraint
lists, which is fine, but using a pure exception here seemed harmless as the
URLs are mostly static and this is a CLI.