### PR TITLE
Sort asana tasks by base project order

### DIFF
--- a/library/Asana/Api/Gid.hs
+++ b/library/Asana/Api/Gid.hs
@@ -1,18 +1,27 @@
 -- | A globally unique identifier
 module Asana.Api.Gid
     ( Gid
+    , AsanaReference(..)
     , gidToText
     , textToGid
     ) where
 
 import RIO
 
-import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Aeson
+  (FromJSON(..), FromJSONKey, ToJSON, ToJSONKey, genericParseJSON)
+import Data.Aeson.Casing (aesonPrefix, snakeCase)
 import RIO.Text (Text)
 
 newtype Gid = Gid { gidToText :: Text }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
   deriving newtype (FromJSON, ToJSON, ToJSONKey, FromJSONKey, Hashable)
+
+newtype AsanaReference = AsanaReference { arGid :: Gid }
+  deriving stock (Eq, Generic, Show)
+
+instance FromJSON AsanaReference where
+  parseJSON = genericParseJSON $ aesonPrefix snakeCase
 
 textToGid :: Text -> Gid
 textToGid = Gid

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -23,7 +23,7 @@ module Asana.Api.Task
 
 import RIO
 
-import Asana.Api.Gid (Gid, gidToText)
+import Asana.Api.Gid (AsanaReference(..), Gid, gidToText)
 import Asana.Api.Named (Named)
 import Asana.Api.Request (HasAsana, getAllParams, getSingle, post, put)
 import Control.Monad.IO.Class (liftIO)
@@ -147,6 +147,7 @@ data Task = Task
   , tGid :: Gid
   , tResourceSubtype :: ResourceSubtype
   , tNotes :: Text
+  , tProjects :: [AsanaReference]
   }
   deriving (Eq, Generic, Show)
 

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -16,6 +16,7 @@ module Asana.App
   , parsePessimistic
   , parseProjectId
   , parseBugProjectId
+  , parseTeamProjectId
   , parseYear
   , parseImport
   , parseSubprojectName
@@ -127,6 +128,10 @@ parseImport = optional (strOption (long "import" <> help "CSV File to import"))
 parseSubprojectName :: Parser (Maybe String)
 parseSubprojectName =
   optional (strOption (long "subproject" <> help "Optional subproject name"))
+
+parseTeamProjectId :: Parser Gid
+parseTeamProjectId =
+  textToGid . T.pack <$> strOption (long "team-project" <> help "SubProject Id")
 
 promptWith :: MonadIO m => (String -> b) -> String -> m b
 promptWith readVar var = liftIO $ do


### PR DESCRIPTION
When running planning poker for a red iteration, we want tasks to show
up in the ordering determined by the top-level project, not the team
(red) project. This does that.

This is a replacement for #20, which has drifted enough to be painful
to merge, and had a little bit of a weird design that we can just avoid
by always requesting a task's projects when requesting a task from
the asana api. The code is a bit shorter and easier to read than in #20,
which has been closed.