### PR TITLE
Get asana building with --pedantic again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ references:
             git ls-files | xargs md5sum > digest
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
-            - v1-{{ .Branch }}-
-            - v1-master-
+            - v2-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
+            - v2-{{ .Branch }}-
+            - v2-master-
       - run:
           name: Upgrade Stack
           command: stack upgrade
@@ -32,7 +32,7 @@ references:
           command: make build
       - save_cache:
           # yamllint disable-line rule:line-length
-          key: v1-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
+          key: v2-{{ .Branch }}-{{ checksum "rdigest" }}-{{ checksum "digest" }}
           paths:
             - ~/.stack
             - ./.stack-work

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/*.dump-hi
 **/*.hie
 *.csv
+.env.asana

--- a/bug-reproduction/Main.hs
+++ b/bug-reproduction/Main.hs
@@ -6,8 +6,6 @@ import Asana.Api
 import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
-import Control.Monad (foldM, when)
-import Data.Maybe (isNothing)
 import Data.Semigroup.Generic (gmappend, gmempty)
 import RIO.Time
 
@@ -20,7 +18,7 @@ data Totals = Totals
   , tReproduced :: [Story]
   , tNotReproduced :: [Story]
   }
-  deriving (Generic)
+  deriving stock Generic
 
 instance Semigroup Totals where
   (<>) = gmappend

--- a/close-iteration/Main.hs
+++ b/close-iteration/Main.hs
@@ -7,9 +7,7 @@ import Asana.Api
 import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
-import Control.Monad (when)
-import Data.Maybe (isJust, isNothing)
-import Data.Semigroup (Sum(..), (<>))
+import Data.Semigroup (Sum(..))
 import Data.Semigroup.Generic (gmappend, gmempty)
 import qualified RIO.Text as T
 
@@ -98,7 +96,7 @@ updateCompletedPoints :: Gid -> [Task] -> AppM AppExt ()
 updateCompletedPoints projectId tasks =
   pooledForConcurrentlyN_ maxRequests tasks $ \task -> do
     let mStory = fromTask (Just projectId) task
-    for_ mStory $ \story@Story {..} -> case getCompletedPoints story of
+    for_ mStory $ \story -> case getCompletedPoints story of
       Nothing ->
         logWarn
           . display
@@ -180,7 +178,8 @@ data CompletionStats = CompletionStats
   , incompleteCompletedPoints :: Sum Integer
   , incompleteCarryOver :: Sum Integer
   , commitment :: Sum Integer
-  } deriving (Generic)
+  }
+  deriving stock Generic
 
 instance Semigroup CompletionStats where
   (<>) = gmappend

--- a/cycle-time/Main.hs
+++ b/cycle-time/Main.hs
@@ -11,7 +11,6 @@ import Asana.Api.Gid (Gid, gidToText)
 import Asana.Api.Project (Project(pCreatedAt, pGid, pName), getProjects)
 import Asana.App
   (AppM, appExt, loadAppWith, parseBugProjectId, parseYear, runApp)
-import Control.Monad (when)
 import qualified Data.Csv as Csv
 import Data.Foldable (maximum, minimum)
 import Data.List (intercalate, nub)

--- a/debt-evaluation/Main.hs
+++ b/debt-evaluation/Main.hs
@@ -27,10 +27,7 @@ import Asana.Api
 import Asana.Api.Gid (Gid, textToGid)
 import Asana.App
 import Asana.Story
-import Control.Monad (guard, when)
 import Data.Foldable (maximum, minimum)
-import Data.Maybe (mapMaybe)
-import RIO.Text (Text)
 import Text.Printf (printf)
 
 newtype AppExt = AppExt
@@ -44,7 +41,7 @@ data Point = Point
   , pImpact :: Double
   , pEffort :: Double
   }
-  deriving Show
+  deriving stock Show
 
 data Priority
   = ThankLess
@@ -61,7 +58,7 @@ data Priority
   | Major
   -- ^ Major projects give good returns, but they are time-consuming. This means
   -- that one major project can "crowd out" many quick wins.
-  deriving (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord)
 
 main :: IO ()
 main = do

--- a/library/Asana/Api/Gid.hs
+++ b/library/Asana/Api/Gid.hs
@@ -11,7 +11,6 @@ import RIO
 import Data.Aeson
   (FromJSON(..), FromJSONKey, ToJSON, ToJSONKey, genericParseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
-import RIO.Text (Text)
 
 newtype Gid = Gid { gidToText :: Text }
   deriving stock (Eq, Generic, Show)

--- a/library/Asana/Api/Named.hs
+++ b/library/Asana/Api/Named.hs
@@ -8,13 +8,12 @@ import RIO
 import Asana.Api.Gid (Gid)
 import Data.Aeson (FromJSON, genericParseJSON, parseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
-import RIO.Text (Text)
 
 data Named = Named
   { nGid :: Gid
   , nName :: Text
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON Named where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase

--- a/library/Asana/Api/Project.hs
+++ b/library/Asana/Api/Project.hs
@@ -9,7 +9,6 @@ import Asana.Api.Gid (Gid)
 import Asana.Api.Request (HasAsana, getAllParams)
 import Data.Aeson (FromJSON, genericParseJSON, parseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
-import RIO.Text (Text)
 import qualified RIO.Text as T
 import RIO.Time (UTCTime)
 

--- a/library/Asana/Api/Request.hs
+++ b/library/Asana/Api/Request.hs
@@ -13,11 +13,8 @@ module Asana.Api.Request
 
 import RIO
 
-import Control.Monad (when)
 import Data.Aeson (FromJSON, ToJSON, Value, genericParseJSON, parseJSON)
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
-import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
 import Network.HTTP.Simple
   ( JSONException(JSONConversionException, JSONParseException)
   , Request
@@ -32,9 +29,7 @@ import Network.HTTP.Simple
   , setRequestMethod
   )
 import Prelude (pred)
-import RIO.Text (Text)
 import qualified RIO.Text as T
-import Text.Read (readMaybe)
 
 class HasAsana env where
   asanaApiAccessKeyL :: Lens' env Text
@@ -46,7 +41,8 @@ maxRequests = 50
 newtype Single a = Single
   { sData :: a
   }
-  deriving (Eq, Generic, Show)
+  deriving newtype (Eq, Show)
+  deriving stock Generic
 
 instance FromJSON a => FromJSON (Single a) where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
@@ -56,7 +52,7 @@ data Page a = Page
   { pData :: [a]
   , pNextPage :: Maybe NextPage
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON a => FromJSON (Page a) where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
@@ -67,7 +63,7 @@ data NextPage = NextPage
   , npPath :: Text
   , npUri :: Text
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON NextPage where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase

--- a/library/Asana/Api/Task.hs
+++ b/library/Asana/Api/Task.hs
@@ -26,14 +26,11 @@ import RIO
 import Asana.Api.Gid (AsanaReference(..), Gid, gidToText)
 import Asana.Api.Named (Named)
 import Asana.Api.Request (HasAsana, getAllParams, getSingle, post, put)
-import Control.Monad.IO.Class (liftIO)
 import Data.Aeson
 import Data.Aeson.Casing (aesonPrefix, snakeCase)
 import Data.List (find, intercalate)
 import Data.Scientific (Scientific)
-import Data.Semigroup ((<>))
 import qualified RIO.HashMap as HashMap
-import RIO.Text (Text)
 import qualified RIO.Text as T
 import RIO.Time
   ( FormatTime
@@ -47,7 +44,8 @@ import RIO.Time
 newtype ApiData a = ApiData
   { adData :: a
   }
-  deriving stock (Generic, Show, Eq)
+  deriving newtype (Show, Eq)
+  deriving stock Generic
 
 instance FromJSON a => FromJSON (ApiData a) where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
@@ -62,7 +60,7 @@ data CustomField
   | CustomEnum Gid Text [EnumOption] (Maybe Text)
   | CustomText Gid Text (Maybe Text)
   | Other -- ^ Unexpected types dumped here
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 newtype CustomFields = CustomFields { getCustomFields :: [CustomField] }
   deriving stock (Show, Eq)
@@ -80,7 +78,7 @@ data EnumOption = EnumOption
   { eoGid :: Gid
   , eoName :: Text
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON EnumOption where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
@@ -124,13 +122,13 @@ data Membership = Membership
   { mProject :: Named
   , mSection :: Maybe Named
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON Membership where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
 
 data ResourceSubtype = DefaultTask | Milestone | Section
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON ResourceSubtype where
   parseJSON =
@@ -149,7 +147,7 @@ data Task = Task
   , tNotes :: Text
   , tProjects :: [AsanaReference]
   }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance FromJSON Task where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase
@@ -168,7 +166,7 @@ data PostTask = PostTask
   , ptNotes :: Text
   , ptParent :: Maybe Gid
   }
-  deriving Generic
+  deriving stock Generic
 
 instance FromJSON PostTask where
   parseJSON = genericParseJSON $ aesonPrefix snakeCase

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -29,9 +29,7 @@ import RIO
 
 import Asana.Api.Gid (Gid, textToGid)
 import Asana.Api.Request (HasAsana(..))
-import Control.Monad.IO.Class (liftIO)
 import Data.Char (toLower)
-import Data.Semigroup ((<>))
 import LoadEnv (loadEnvFrom)
 import Options.Applicative
   ( Parser
@@ -47,10 +45,9 @@ import Options.Applicative
   , progDesc
   , strOption
   )
-import RIO.Text (Text)
 import qualified RIO.Text as T
 import System.Environment (getEnv)
-import System.IO (getLine, putStr, stderr)
+import System.IO (getLine, putStr)
 
 data AppWith ext = App
   { appApiAccessKey :: Text

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -7,13 +7,11 @@ module Asana.App
   , AppWith(..)
   , AppM
   , Perspective(..)
-  , loadApp
   , loadAppWith
   , runApp
   , liftIO
   -- * Argument parsers
   , parseIgnoreNoCanDo
-  , parsePessimistic
   , parseProjectId
   , parseBugProjectId
   , parseTeamProjectId
@@ -80,9 +78,6 @@ runApp app action = do
     logInfo "Starting app"
     action
 
-loadApp :: IO App
-loadApp = loadAppWith $ pure ()
-
 loadAppWith :: forall ext . Parser ext -> IO (AppWith ext)
 loadAppWith parseExt = do
   loadEnvFrom ".env.asana"
@@ -104,9 +99,6 @@ loadAppWith parseExt = do
 
 parseIgnoreNoCanDo :: Parser Bool
 parseIgnoreNoCanDo = flag False True (long "ignore-no-can-do")
-
-parsePessimistic :: Parser Perspective
-parsePessimistic = flag Optimistic Pessimistic (long "pessimistic")
 
 parseProjectId :: Parser Gid
 parseProjectId =

--- a/library/Asana/Story.hs
+++ b/library/Asana/Story.hs
@@ -9,10 +9,7 @@ import RIO
 
 import Asana.Api
 import Asana.Api.Gid (Gid, gidToText)
-import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Scientific (Scientific)
-import Data.Semigroup ((<>))
-import RIO.Text (Text)
 import qualified RIO.Text as T
 import RIO.Time (UTCTime)
 
@@ -32,7 +29,7 @@ data Story = Story
   , sCapitalized :: Bool
   , sGid :: Gid
   }
-  deriving Show
+  deriving stock Show
 
 fromTask
   :: Maybe Gid

--- a/planning-poker/Main.hs
+++ b/planning-poker/Main.hs
@@ -112,7 +112,7 @@ data PlanningPokerTask = PlanningPokerTask
   , acceptanceCriteria :: Text
   , storyPoints :: Maybe Integer
   }
-  deriving stock (Show)
+  deriving stock Show
 
 instance FromNamedRecord PlanningPokerTask where
   parseNamedRecord m =
@@ -168,6 +168,7 @@ toPlanningPokerTask task@Task {..} = PlanningPokerTask
   , storyPoints = extractCost task
   }
 
+describeMemberships :: [Membership] -> Text
 describeMemberships = ul . mconcat . map describeMembership
  where
   ul text = "<ul>" <> text <> "</ul>"

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,11 +5,10 @@ packages:
 # build for profiling, consider using a separate .stack-work directory or
 # reversing the flag using `fno-ignore-optim-changes`.
 ghc-options:
-  "$locals":
-    -ddump-to-file
-    -ddump-hi
+  "$locals": -fwrite-ide-info
     -fhide-source-paths
     -Weverything
+    -Wno-missing-exported-signatures
     -Wno-missed-specialisations
     -Wno-all-missed-specialisations
     -Wno-unsafe
@@ -17,5 +16,12 @@ ghc-options:
     -Wno-missing-local-signatures
     -Wno-monomorphism-restriction
     -Wno-missing-import-lists
+    -Wno-missing-export-lists
+    -Wno-incomplete-uni-patterns
+    -Wno-partial-fields
     -Wno-implicit-prelude
+    -Wno-deriving-typeable
+    -Wno-missing-monadfail-instances
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
     -fignore-optim-changes

--- a/start-iteration/Main.hs
+++ b/start-iteration/Main.hs
@@ -7,11 +7,8 @@ import Asana.Api
 import Asana.Api.Gid (Gid)
 import Asana.App
 import Asana.Story
-import Control.Monad (unless, when)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
-import Data.List (partition, tail, zipWith)
-import Data.Maybe (isJust, isNothing, mapMaybe)
-import Data.Semigroup ((<>))
+import Data.List (partition, tail)
 import qualified RIO.Text as T
 
 data AppExt = AppExt

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,5 +1,8 @@
 { roots =
   [ "^Main\\.main\$"
+  , "^Paths_.*"
+  , "^Asana.Api.Request.*$"
+  , "^Asana.Api.Task.*$"
   ]
 , type-class-roots = True
 }

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,0 +1,5 @@
+{ roots =
+  [ "^Main\\.main\$"
+  ]
+, type-class-roots = True
+}


### PR DESCRIPTION
I noticed that both `Make` and `stack build --pedantic` were broken. Specifically, `weeder` no longer needs a file path argument (we were passing `.`), and the top level `RIO` module exports a _lot_ more than it used to, so may of our `Control.Monad`, `Data.Maybe`, etc. imports were redundant. Also removed some weeds.