### PR TITLE
Check lead time by date range

### DIFF
--- a/library/Asana/Api/Project.hs
+++ b/library/Asana/Api/Project.hs
@@ -25,6 +25,19 @@ instance FromJSON Project where
 getProjects
   :: (MonadUnliftIO m, MonadReader env m, HasLogFunc env, HasAsana env)
   => m [Project]
-getProjects = getAllParams
+getProjects = mconcat <$> traverse
+  getProjectsForTeam
+  [engineeringTeam, studentTeam, educatorTeam, platformTeam]
+ where
+  engineeringTeam = "12760955045995"
+  studentTeam = "1201325186562301"
+  educatorTeam = "1201325186562310"
+  platformTeam = "1200567751522718"
+
+getProjectsForTeam
+  :: (MonadUnliftIO m, MonadReader env m, HasLogFunc env, HasAsana env)
+  => String
+  -> m [Project]
+getProjectsForTeam team = getAllParams
   (T.unpack "/projects/")
-  [("team", "12760955045995"), ("opt_fields", "created_at,name")]
+  [("team", team), ("opt_fields", "created_at,name")]

--- a/library/Asana/App.hs
+++ b/library/Asana/App.hs
@@ -16,6 +16,7 @@ module Asana.App
   , parseBugProjectId
   , parseTeamProjectId
   , parseYear
+  , parseDate
   , parseImport
   , parseSubprojectName
   -- * Prompts
@@ -44,6 +45,7 @@ import Options.Applicative
   , strOption
   )
 import qualified RIO.Text as T
+import RIO.Time
 import System.Environment (getEnv)
 import System.IO (getLine, putStr)
 
@@ -110,6 +112,10 @@ parseBugProjectId =
 
 parseYear :: Parser Integer
 parseYear = option auto (long "year" <> help "The year to view")
+
+parseDate :: String -> Parser UTCTime
+parseDate name = parseTimeOrError False defaultTimeLocale "%Y-%m-%d"
+  <$> strOption (long name <> help "[UTCTime]")
 
 parseImport :: Parser (Maybe FilePath)
 parseImport = optional (strOption (long "import" <> help "CSV File to import"))


### PR DESCRIPTION
This lead time metric is useful for understanding the health of our
process. Measuring a year is not very useful, but measuring arbitrary
ranges of time is.

- Date ranges are now parsed instead of years.
- Newer asana projects have been included in the `getProjects` function.
- Iteration naming criteria is updated to match current practices.