### PR TITLE
Add tool for finding Educator Zombie Stories

### DIFF
--- a/asana-cli.cabal
+++ b/asana-cli.cabal
@@ -261,7 +261,6 @@ executable educator-zombie-tasks
     , asana
     , asana-cli
     , base
-    , hashable
     , http-conduit
     , scientific
     , statistics

--- a/asana-cli.cabal
+++ b/asana-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -222,6 +222,54 @@ executable debt-evaluation
     , asana-cli
     , base
     , unliftio
+  default-language: Haskell2010
+
+executable educator-zombie-tasks
+  main-is: Main.hs
+  other-modules:
+      Paths_asana_cli
+  hs-source-dirs:
+      educator-zombie-tasks
+  default-extensions:
+      BangPatterns
+      DataKinds
+      DeriveAnyClass
+      DeriveFoldable
+      DeriveFunctor
+      DeriveGeneric
+      DeriveLift
+      DeriveTraversable
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      NoImplicitPrelude
+      NoMonomorphismRestriction
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TypeApplications
+      TypeFamilies
+  build-depends:
+      aeson
+    , aeson-casing
+    , asana
+    , asana-cli
+    , base
+    , hashable
+    , http-conduit
+    , scientific
+    , statistics
+    , text
+    , time
+    , unliftio
+    , unordered-containers
+    , vector
   default-language: Haskell2010
 
 executable planning-poker

--- a/educator-zombie-tasks/Main.hs
+++ b/educator-zombie-tasks/Main.hs
@@ -1,0 +1,402 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TupleSections #-}
+-- TODO upstream orphan
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | A tool for finding tasks that are taking longer than average
+module Main (main) where
+
+import Asana.Prelude
+
+import Asana.Api.CustomField
+  (CustomField(CustomNumber), CustomFields(getCustomFields))
+import Asana.Api.Gid (AsanaReference(..), Gid, gidToText, textToGid)
+import Asana.Api.Named (Named(..))
+import Asana.Api.Project (Project(..))
+import Asana.Api.Request
+import Asana.Api.Task
+import Asana.App (AppM, loadAppWith, runApp)
+import Data.Aeson
+import Data.Aeson.Casing (aesonPrefix, snakeCase)
+import Data.Bifunctor (bimap)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashSet as HashSet
+import Data.Hashable (Hashable(..))
+import Data.List (find, nub)
+import Data.Scientific (Scientific)
+import Data.String (fromString)
+import Data.Text (intercalate, splitOn)
+import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import qualified Data.Vector as V
+import Network.HTTP.Simple (JSONException)
+import Numeric.Natural
+import Statistics.Sample (mean)
+import UnliftIO.Async (pooledForConcurrentlyN)
+import UnliftIO.Exception (throwString)
+
+-- | How many iterations we should look at for finding historical averages (including current)
+numberOfIterationsForAverages :: Num p => p
+numberOfIterationsForAverages = 5
+
+main :: IO ()
+main = do
+  app <- loadAppWith $ pure ()
+  runApp app $ do
+    logDebug "Fetch projects"
+
+    -- Get team iteration projects
+    iterations <- mapMaybe parseEducatorIteration <$> getProjects
+    logInfo
+      $ "Found iterations: "
+      <> tshow (fmap iterationNumber iterations)
+      :# []
+
+    when (null iterations) $ throwString "Found no Educator iterations!"
+
+    let maxIteration = maximum iterations
+
+    logInfo
+      $ "Latest iteration"
+      :# ["iterationNumber" .= iterationNumber maxIteration]
+
+    -- Try to find N or so iterations.
+    --
+    -- - current may be empty (e.g. just started, created ahead of time)
+    -- - may have gaps (e.g. if we did a bug-only iteration or a debt-only iteration)
+    --
+    let
+      likelyLastNIterations
+        = [iterationNumber maxIteration - (numberOfIterationsForAverages - 1) .. iterationNumber
+          maxIteration]
+      lastNOrSo =
+        filter ((`elem` likelyLastNIterations) . iterationNumber) iterations
+
+    when (length lastNOrSo < 3) $ do
+      logError
+        $ "Need at least 3 iterations to make this calculation"
+        :# ["found" .= fmap iterationNumber lastNOrSo]
+      throwString "Not enough iterations!"
+
+    logInfo
+      $ "Iterations to search"
+      :# ["iterationNumbers" .= fmap iterationNumber lastNOrSo]
+
+    taskGids <- fetchRelevantTaskGids lastNOrSo
+
+    allIterationTasks <- pooledForConcurrentlyN maxRequests taskGids getTask
+
+    -- Get events that happen against each story
+    taskStories <-
+      fmap (HashMap.fromList . catMaybes)
+      $ pooledForConcurrentlyN maxRequests taskGids
+      $ \taskId -> fmap (taskId, ) <$> getTaskStories taskId
+
+    -- Assume ics are the assignees of the iteration tasks
+    let ics = HashSet.fromList $ catMaybes $ tAssignee <$> allIterationTasks
+
+    let
+      -- For historical data
+      doneTasks =
+        mapMaybe (parseDoneTask ics iterations taskStories) allIterationTasks
+
+      -- Potential current zombies
+      wipTasks =
+        mapMaybe (parseWipTask ics iterations taskStories) allIterationTasks
+
+    logInfo
+      $ "Relevant tasks"
+      :# [ "totalTasksInIterations" .= length allIterationTasks
+         , "tasksWithStories" .= HashMap.size taskStories
+         , "doneTasksInIterations" .= length doneTasks
+         , "wipTasksInIterations" .= length wipTasks
+         , "icsInIterations"
+           .= intercalate ", " (HashSet.toList $ HashSet.map nName ics)
+         ]
+
+    for_ doneTasks $ \task -> do
+      logDebug $ "Done tasks" :# []
+      logDebug $ tshow task :# []
+
+    for_ wipTasks $ \task -> do
+      logInfo
+        $ "WIP Task"
+        :# [ "name" .= wipName task
+           , "id" .= wipGid task
+           , "roughStartedAt" .= sCreatedAt (wipConsideredStartedBecause task)
+           ]
+
+    let
+      averageDaysToCompletePoints =
+        HashMap.map (toDays . mean . V.fromList . fmap realToFrac)
+          $ HashMap.fromListWith (<>)
+          $ (doneCost &&& pure . timeToComplete)
+          <$> doneTasks
+
+    logInfo $ "Average days to complete points" :# fmap
+      (uncurry (.=)
+      . bimap ((<> " point(s)") . fromString . show) ((<> " day(s)") . show)
+      )
+      (HashMap.toList averageDaysToCompletePoints)
+
+    now <- liftIO getCurrentTime
+
+    let
+      zombieTasks =
+        mapMaybe (parseZombieSummary now averageDaysToCompletePoints) wipTasks
+
+    for_ zombieTasks
+      $ \ZombieSummary { daysWip, averageDaysForPoints, zombieTask } -> do
+          logInfo
+            $ "Zombie Task"
+            :# [ "name" .= wipName zombieTask
+               , "id" .= wipGid zombieTask
+               , "daysWip" .= daysWip
+               , "averageDaysForPoints" .= averageDaysForPoints
+               ]
+          let AsanaStory {..} = wipConsideredStartedBecause zombieTask
+          logDebug
+            $ "Asana Story (event) which we believe means this story was started at the given time"
+            :# [ "gid" .= sGid
+               , "createdAt" .= sCreatedAt
+               , "createdBy" .= fmap arGid sCreatedBy
+               , "text" .= sText
+               , "resourceSubtype" .= show sResourceSubtype
+               , "assignee" .= fmap arGid sAssignee
+               , "project" .= fmap arGid sProject
+               ]
+
+-- TODO upstream orphan
+instance Hashable Named where
+  hashWithSalt s Named {..} = hashWithSalt s nGid
+  hash Named {..} = hash nGid
+
+-- | Figure out (rough) start time for the task from its "stories"
+--
+-- This is the tricky bit... Let's consider a story started, the first time it's
+--   * Moved into an actual iteration, or
+--   * Assigned to an IC
+--
+parseRoughStartStory
+  :: (Functor t1, Foldable t1, Foldable t2)
+  => HashSet.HashSet Named
+  -> t1 EducatorIteration
+  -> t2 AsanaStory
+  -> Maybe AsanaStory
+parseRoughStartStory ics iterations taskStories = find
+  parseTypicalIndicatorOfTaskStart
+  taskStories
+ where
+  parseTypicalIndicatorOfTaskStart AsanaStory {..} = case sResourceSubtype of
+    AddedToProject ->
+      any ((`elem` fmap iterationProjectGid iterations) . arGid) sProject
+    Assigned -> any ((`HashSet.member` HashSet.map nGid ics) . arGid) sAssignee
+    Don'tCare -> False
+
+-- | "Completed" task
+data DoneTask = DoneTask
+  { doneAt :: UTCTime
+  , doneConsideredStartedBecause :: AsanaStory
+  , doneCost :: Scientific
+  }
+  deriving stock Show
+
+timeToComplete :: DoneTask -> NominalDiffTime
+timeToComplete DoneTask { doneAt, doneConsideredStartedBecause = AsanaStory { sCreatedAt } }
+  = diffUTCTime doneAt sCreatedAt
+
+parseDoneTask
+  :: (Functor t1, Foldable t1, Foldable t2)
+  => HashSet.HashSet Named
+  -> t1 EducatorIteration
+  -> HashMap.HashMap Gid (t2 AsanaStory)
+  -> Task
+  -> Maybe DoneTask
+parseDoneTask ics iterations taskStoriesLookup Task { tCompleted, tCompletedAt, tCustomFields, tGid }
+  = do
+    guard tCompleted
+    doneAt <- tCompletedAt
+    doneCost <- parseCostFromCustomFields tCustomFields
+    taskStories <- HashMap.lookup tGid taskStoriesLookup
+    doneConsideredStartedBecause <- parseRoughStartStory
+      ics
+      iterations
+      taskStories
+    pure DoneTask { doneAt, doneCost, doneConsideredStartedBecause }
+
+parseCostFromCustomFields :: CustomFields -> Maybe Scientific
+parseCostFromCustomFields = listToMaybe . mapMaybe parseCost . getCustomFields
+
+parseCost :: CustomField -> Maybe Scientific
+parseCost = \case
+  CustomNumber gid _ mCost | gid == costCustomFieldGid -> mCost
+  _ -> Nothing
+
+-- | In progress task
+data WipTask = WipTask
+  { wipName :: Text
+  , wipGid :: Gid
+  , wipTotalCost :: Scientific
+  -- ^
+  --
+  -- We just care about total cost not carry-over.
+  --
+  , wipConsideredStartedBecause :: AsanaStory
+  }
+
+parseWipTask
+  :: (Functor t1, Foldable t1, Foldable t2)
+  => HashSet.HashSet Named
+  -> t1 EducatorIteration
+  -> HashMap.HashMap Gid (t2 AsanaStory)
+  -> Task
+  -> Maybe WipTask
+parseWipTask ics iterations taskStoriesLookup Task { tName, tCompleted, tCustomFields, tGid }
+  = do
+    guard $ not tCompleted
+    wipTotalCost <- parseCostFromCustomFields tCustomFields
+    taskStories <- HashMap.lookup tGid taskStoriesLookup
+    wipConsideredStartedBecause <- parseRoughStartStory
+      ics
+      iterations
+      taskStories
+    pure WipTask { wipTotalCost, wipConsideredStartedBecause, wipName, wipGid }
+
+ where
+  wipName = tName
+  wipGid = tGid
+
+data ZombieSummary = ZombieSummary
+  { zombieTask :: WipTask
+  , daysWip :: Int
+  , averageDaysForPoints :: Int
+  }
+
+parseZombieSummary
+  :: UTCTime -> HashMap.HashMap Scientific Int -> WipTask -> Maybe ZombieSummary
+parseZombieSummary now averageTimeForCost wipTask@WipTask { wipTotalCost, wipConsideredStartedBecause = AsanaStory { sCreatedAt } }
+  = do
+    averageDaysForPoints <- HashMap.lookup wipTotalCost averageTimeForCost
+    guard $ daysWip > averageDaysForPoints
+    pure ZombieSummary { zombieTask = wipTask, daysWip, averageDaysForPoints }
+  where daysWip = toDays $ realToFrac $ diffUTCTime now sCreatedAt
+
+costCustomFieldGid :: Gid
+costCustomFieldGid = textToGid "293622495894291"
+
+toDays :: Double -> Int
+toDays = floor . (/ 86400)
+
+data EducatorIteration = EducatorIteration
+  { iterationNumber :: Natural
+  , iterationProjectCreatedAt :: UTCTime
+  , iterationProjectGid :: Gid
+  }
+  deriving stock (Eq, Show)
+
+instance Ord EducatorIteration where
+  compare a b = compare (iterationNumber a) $ iterationNumber b
+
+parseEducatorIteration :: Project -> Maybe EducatorIteration
+parseEducatorIteration Project { pName, pCreatedAt = iterationProjectCreatedAt, pGid = iterationProjectGid }
+  = case splitOn " " pName of
+    ["Educator", rawIterationNumber] ->
+      fmap mkIteration $ readMaybe $ unpack rawIterationNumber
+    _ -> Nothing
+ where
+  mkIteration iterationNumber = EducatorIteration
+    { iterationNumber
+    , iterationProjectCreatedAt
+    , iterationProjectGid
+    }
+
+fetchRelevantTaskGids :: Traversable t => t EducatorIteration -> AppM () [Gid]
+fetchRelevantTaskGids iterations =
+  fmap (nub . concat)
+    . pooledForConcurrentlyN maxRequests iterations
+    $ \EducatorIteration { iterationProjectGid } -> do
+        logDebug . fromString $ "Project tasks: " <> show
+          (gidToText iterationProjectGid)
+        fmap nGid <$> getProjectTasks iterationProjectGid AllTasks
+
+getProjects
+  :: (MonadUnliftIO m, MonadLogger m, MonadReader env m, HasAsanaAccessKey env)
+  => m [Project]
+getProjects = getProjectsForTeam educatorTeam
+  where educatorTeam = "1201325186562310"
+
+getProjectsForTeam
+  :: (MonadUnliftIO m, MonadLogger m, MonadReader env m, HasAsanaAccessKey env)
+  => String
+  -> m [Project]
+getProjectsForTeam team = getAllParams
+  (unpack "/projects/")
+  [("team", team), ("opt_fields", "created_at,name")]
+
+-- TODO upstream stories stuff
+-- "Story" is Asana's term for an event that happens against some entity.
+-- For this logic we only care about a task's stories.
+
+-- opt_fields=project,created_at,created_by,text,type,resource_subtype,assignee
+
+
+-- |
+--
+-- Only enumerates the types we care about for this logic.
+--
+data StoryResourceSubtype
+  = AddedToProject
+  | Assigned
+  | Don'tCare
+  deriving stock (Generic, Show, Eq)
+
+instance FromJSON StoryResourceSubtype where
+  parseJSON = \case
+    String "added_to_project" -> pure AddedToProject
+    String "assigned" -> pure AddedToProject
+    String _ -> pure Don'tCare
+    _ -> mzero
+
+-- |
+--
+-- Named 'AsanaStory' to disambiguate with this codebase's 'Story' which
+-- represents an Asana 'Task' (i.e. a 'Task' with Freckle-specific fields).
+--
+data AsanaStory = AsanaStory
+  { sGid :: Gid
+  , sCreatedAt :: UTCTime
+  , sCreatedBy :: Maybe AsanaReference
+  , sText :: Maybe Text
+  , sResourceSubtype :: StoryResourceSubtype
+  , sAssignee :: Maybe AsanaReference
+  -- ^
+  --
+  -- Available when @resource_subtype@ is @assigned@
+  --
+  , sProject :: Maybe AsanaReference
+  -- ^
+  --
+  -- Available when @resource_subtype@ is @added_to_project@
+  --
+  }
+  deriving stock (Eq, Generic, Show)
+
+instance FromJSON AsanaStory where
+  parseJSON = genericParseJSON $ aesonPrefix snakeCase
+
+getTaskStories
+  :: (MonadUnliftIO m, MonadLogger m, MonadReader env m, HasAsanaAccessKey env)
+  => Gid
+  -> m (Maybe [AsanaStory])
+getTaskStories taskId = fmap Just fetch `catch` ignoreAndLogError
+ where
+  fetch = getAllParams
+    (unpack $ "/tasks/" <> gidToText taskId <> "/stories")
+    [ ( "opt_fields"
+      , "project,created_at,created_by,text,resource_subtype,assignee,text"
+      )
+    ]
+
+  ignoreAndLogError :: (MonadLogger m) => JSONException -> m (Maybe a)
+  ignoreAndLogError err = do
+    logWarn $ tshow err :# ["fetchingTask" .= taskId]
+    pure Nothing

--- a/package.yaml
+++ b/package.yaml
@@ -95,6 +95,23 @@ executables:
       - time
       - unliftio
       - vector
+  educator-zombie-tasks:
+    main: Main.hs
+    source-dirs: educator-zombie-tasks
+    dependencies:
+      - aeson
+      - aeson-casing
+      - asana
+      - asana-cli
+      - hashable
+      - http-conduit
+      - scientific
+      - statistics
+      - text
+      - time
+      - unliftio
+      - unordered-containers
+      - vector
   update-task:
     main: Main.hs
     source-dirs: update-task

--- a/package.yaml
+++ b/package.yaml
@@ -103,7 +103,6 @@ executables:
       - aeson-casing
       - asana
       - asana-cli
-      - hashable
       - http-conduit
       - scientific
       - statistics


### PR DESCRIPTION
Goal: give us a signal when a task's taking awhile to get us to discuss the task. E.g. We could decided to pair to or talk through blockers etc... This is all about starting the conversations.

Here's the process changelog that's driving this: https://renaissancelearning.atlassian.net/wiki/spaces/FTE/pages/42818306169/2023-04-24+Push+Model+of+Getting+Help

**Terminology note** Asana calls events that happen to a task "stories". This is very confusing so I'm trying to use "task" throughout to talk about Asana tasks and what our team calls "tasks" or "stories".

This was first built around the cycle-time tool: https://github.com/freckle/asana/tree/main/cycle-time

General algorithm:
 - Parse iterations by name ("Educator N")
 - Take last 5 (may take less if there are gaps for some reason)
 - Get all tasks for those iterations
 - Get all stories (asana events) for those tasks
 - Find ICs by looking at assignees (this might be wrong sometimes... Generally I'm noticing that if it's in the iteration, it's assigned to an IC)
 - Find "done" tasks (those with a start and an end)
 - Find "WIP" tasks (those with just a start)
 - Average how many days "done" tasks take, per point value
 - Find "WIP" tasks that are taking more days than the average for their points

Figuring out the _start_ date is the hard part... The heuristic I've used it to find the first "story" (asana's name for an event) that reflects
 - ~~the task being assigned to a known IC or~~ (no longer consider this due to slack discussion)
 - the task being moved into a known iteration

Along the way if something "fails" (e.g. can't find a start date, assigned to someone else), it's simple excluded from the computations/checks.

Here's the example output at this time (only one zombie ATM)
```shell
$ stack run educator-zombie-tasks
2023-04-25 16:35:16 [info     ] Starting app
2023-04-25 16:35:16 [info     ] Found iterations: [182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219]
2023-04-25 16:35:16 [info     ] Latest iteration                iterationNumber=219
2023-04-25 16:35:16 [info     ] Iterations to search            iterationNumbers=[215, 216, 217, 218, 219]
2023-04-25 16:35:21 [info     ] Relevant tasks                  doneTasksInIterations=39 icsInIterations=[...] tasksWithStories=43 totalTasksInIterations=43 wipTasksInIterations=3
2023-04-25 16:35:21 [info     ] WIP Task                        id=1204285486850983 name=A/B test surface challenging questions on Assignments report  roughStartedAt=2023-04-19T16:04:00.357Z
2023-04-25 16:35:21 [info     ] WIP Task                        id=1203989018545059 name=Optimize `getContentAreaSkillsR` roughStartedAt=2023-04-06T18:29:32.876Z
2023-04-25 16:35:21 [info     ] WIP Task                        id=1203963501833948 name=As a teacher in the treatment group, I can see a recommendation for assigning PreTP to students who need it in the TP flow roughStartedAt=2023-04-19T18:07:11.833Z
2023-04-25 16:35:21 [info     ] Average days to complete points 0.0 point(s)=2 day(s) 1.0 point(s)=2 day(s) 2.0 point(s)=4 day(s) 3.0 point(s)=8 day(s) 5.0 point(s)=13 day(s)
2023-04-25 16:35:21 [info     ] Zombie Task                     averageDaysForPoints=8 daysWip=18 id=1203989018545059 name=Optimize `getContentAreaSkillsR`
```

There should probably be a follow up to get some of these things into our `asana` package (e.g. orphans, story-stuff).